### PR TITLE
Refactoring entire code base to short array syntax and spacing.

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -93,9 +93,9 @@ class Mailchimp {
 
     $this->endpoint = str_replace(Mailchimp::DEFAULT_DATA_CENTER, $dc, $this->endpoint);
 
-    $this->client = new Client(array(
+    $this->client = new Client([
       'timeout' => $timeout,
-    ));
+    ]);
   }
 
   /**
@@ -128,19 +128,20 @@ class Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#create-post_batches
    */
   public function processBatchOperations() {
-    $parameters = array(
+    $parameters = [
       'operations' => $this->batch_operations,
-    );
+    ];
 
     try {
       $response = $this->request('POST', '/batches', NULL, $parameters);
 
       // Reset batch operations.
-      $this->batch_operations = array();
+      $this->batch_operations = [];
 
       return $response;
 
-    } catch (MailchimpAPIException $e) {
+    }
+    catch (MailchimpAPIException $e) {
       $message = 'Failed to process batch operations: ' . $e->getMessage();
       throw new MailchimpAPIException($message, $e->getCode(), $e);
     }
@@ -155,9 +156,9 @@ class Mailchimp {
    * @return object
    */
   public function getBatchOperation($batch_id) {
-    $tokens = array(
+    $tokens = [
       'batch_id' => $batch_id,
-    );
+    ];
 
     return $this->request('GET', '/batches/{batch_id}', $tokens);
   }
@@ -179,15 +180,15 @@ class Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#create-post_batches
    */
-  protected function addBatchOperation($method, $path, $parameters = array()) {
+  protected function addBatchOperation($method, $path, $parameters = []) {
     if (empty($method) || empty($path)) {
       throw new MailchimpAPIException('Cannot add batch operation without a method and path.');
     }
 
-    $op = (object) array(
+    $op = (object) [
       'method' => $method,
       'path' => $path,
-    );
+    ];
 
     if (!empty($parameters)) {
       if ($method == 'GET') {
@@ -199,7 +200,7 @@ class Mailchimp {
     }
 
     if (empty($this->batch_operations)) {
-      $this->batch_operations = array();
+      $this->batch_operations = [];
     }
 
     $this->batch_operations[] = $op;
@@ -237,11 +238,11 @@ class Mailchimp {
     }
 
     // Set default request options with auth header.
-    $options = array(
-      'headers' => array(
+    $options = [
+      'headers' => [
         'Authorization' => $this->api_user . ' ' . $this->api_key,
-      ),
-    );
+      ],
+    ];
 
     // Add trigger error header if a debug error code has been set.
     if (!empty($this->debug_error_code)) {
@@ -265,7 +266,8 @@ class Mailchimp {
 
       return $data;
 
-    } catch (RequestException $e) {
+    }
+    catch (RequestException $e) {
       $response = $e->getResponse();
       if (!empty($response)) {
         $message = $e->getResponse()->getBody();

--- a/src/MailchimpAPIException.php
+++ b/src/MailchimpAPIException.php
@@ -9,7 +9,7 @@ class MailchimpAPIException extends Exception {
   /**
    * @inheritdoc
    */
-  public function __construct($message = "", $code = 0, Exception $previous = null) {
+  public function __construct($message = "", $code = 0, Exception $previous = NULL) {
     // Construct message from JSON if required.
     if (substr($message, 0, 1) == '{') {
       $message_obj = json_decode($message);

--- a/src/MailchimpCampaigns.php
+++ b/src/MailchimpCampaigns.php
@@ -23,7 +23,7 @@ class MailchimpCampaigns extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#read-get_campaigns
    */
-  public function getCampaigns($parameters = array()) {
+  public function getCampaigns($parameters = []) {
     return $this->request('GET', '/campaigns', NULL, $parameters);
   }
 
@@ -39,10 +39,10 @@ class MailchimpCampaigns extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#read-get_campaigns_campaign_id
    */
-  public function getCampaign($campaign_id, $parameters = array()) {
-    $tokens = array(
+  public function getCampaign($campaign_id, $parameters = []) {
+    $tokens = [
       'campaign_id' => $campaign_id,
-    );
+    ];
 
     return $this->request('GET', '/campaigns/{campaign_id}', $tokens, $parameters);
   }
@@ -65,12 +65,12 @@ class MailchimpCampaigns extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#create-post_campaigns
    */
-  public function addCampaign($type, $recipients, $settings, $parameters = array(), $batch = FALSE) {
-    $parameters += array(
+  public function addCampaign($type, $recipients, $settings, $parameters = [], $batch = FALSE) {
+    $parameters += [
       'type' => $type,
       'recipients' => $recipients,
       'settings' => $settings,
-    );
+    ];
 
     return $this->request('POST', '/campaigns', NULL, $parameters, $batch);
   }
@@ -87,10 +87,10 @@ class MailchimpCampaigns extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/content/#edit-put_campaigns_campaign_id_content
    */
-  public function setCampaignContent($campaign_id, $parameters = array()) {
-    $tokens = array(
+  public function setCampaignContent($campaign_id, $parameters = []) {
+    $tokens = [
       'campaign_id' => $campaign_id,
-    );
+    ];
 
     return $this->request('PUT', '/campaigns/{campaign_id}/content', $tokens, $parameters);
   }
@@ -115,16 +115,16 @@ class MailchimpCampaigns extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#edit-patch_campaigns_campaign_id
    */
-  public function updateCampaign($campaign_id, $type, $recipients, $settings, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function updateCampaign($campaign_id, $type, $recipients, $settings, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'campaign_id' => $campaign_id,
-    );
+    ];
 
-    $parameters += array(
+    $parameters += [
       'type' => $type,
       'recipients' => $recipients,
       'settings' => $settings,
-    );
+    ];
 
     return $this->request('PATCH', '/campaigns/{campaign_id}', $tokens, $parameters, $batch);
   }
@@ -147,15 +147,15 @@ class MailchimpCampaigns extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#action-post_campaigns_campaign_id_actions_test
    */
-  public function sendTest($campaign_id, $test_emails, $send_type, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function sendTest($campaign_id, $test_emails, $send_type, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'campaign_id' => $campaign_id,
-    );
+    ];
 
-    $parameters += array(
+    $parameters += [
       'test_emails' => $test_emails,
       'send_type' => $send_type,
-    );
+    ];
 
     return $this->request('POST', '/campaigns/{campaign_id}/actions/test', $tokens, $parameters, $batch);
   }
@@ -173,9 +173,9 @@ class MailchimpCampaigns extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#action-post_campaigns_campaign_id_actions_send
    */
   public function send($campaign_id, $batch = FALSE) {
-    $tokens = array(
+    $tokens = [
       'campaign_id' => $campaign_id,
-    );
+    ];
 
     return $this->request('POST', '/campaigns/{campaign_id}/actions/send', $tokens, NULL, $batch);
   }
@@ -191,9 +191,9 @@ class MailchimpCampaigns extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#delete-delete_campaigns_campaign_id
    */
   public function delete($campaign_id) {
-    $tokens = array(
+    $tokens = [
       'campaign_id' => $campaign_id,
-    );
+    ];
 
     return $this->request('DELETE', '/campaigns/{campaign_id}', $tokens);
   }

--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -497,8 +497,7 @@ class MailchimpLists extends Mailchimp {
           if ($e->getCode() !== 404) {
             // 404 indicates the email address is not subscribed to this list
             // and can be safely ignored. Surface all other exceptions.
-            throw new MailchimpAPIException($e->getResponse()
-              ->getBody(), $e->getCode(), $e);
+            throw new MailchimpAPIException($e->getResponse()->getBody(), $e->getCode(), $e);
           }
         }
       }

--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -19,7 +19,7 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/#read-get_lists
    */
-  public function getLists($parameters = array()) {
+  public function getLists($parameters = []) {
     return $this->request('GET', '/lists', NULL, $parameters);
   }
 
@@ -35,10 +35,10 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/#read-get_lists_list_id
    */
-  public function getList($list_id, $parameters = array()) {
-    $tokens = array(
+  public function getList($list_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}', $tokens, $parameters);
   }
@@ -55,10 +55,10 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/interest-categories/#read-get_lists_list_id_interest_categories
    */
-  public function getInterestCategories($list_id, $parameters = array()) {
-    $tokens = array(
+  public function getInterestCategories($list_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/interest-categories', $tokens, $parameters);
   }
@@ -77,11 +77,11 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/interest-categories/interests/#read-get_lists_list_id_interest_categories_interest_category_id_interests
    */
-  public function getInterests($list_id, $interest_category_id, $parameters = array()) {
-    $tokens = array(
+  public function getInterests($list_id, $interest_category_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
       'interest_category_id' => $interest_category_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/interest-categories/{interest_category_id}/interests', $tokens, $parameters);
   }
@@ -98,10 +98,10 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/merge-fields/#read-get_lists_list_id_merge_fields
    */
-  public function getMergeFields($list_id, $parameters = array()) {
-    $tokens = array(
+  public function getMergeFields($list_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/merge-fields', $tokens, $parameters);
   }
@@ -118,10 +118,10 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#read-get_lists_list_id_members
    */
-  public function getMembers($list_id, $parameters = array()) {
-    $tokens = array(
+  public function getMembers($list_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/members', $tokens, $parameters);
   }
@@ -140,11 +140,11 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#read-get_lists_list_id_members_subscriber_hash
    */
-  public function getMemberInfo($list_id, $email, $parameters = array()) {
-    $tokens = array(
+  public function getMemberInfo($list_id, $email, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
       'subscriber_hash' => md5(strtolower($email)),
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters);
   }
@@ -163,11 +163,11 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/activity/#read-get_lists_list_id_members_subscriber_hash_activity
    */
-  public function getMemberActivity($list_id, $email, $parameters = array()) {
-    $tokens = array(
+  public function getMemberActivity($list_id, $email, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
       'subscriber_hash' => md5(strtolower($email)),
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}/activity', $tokens, $parameters);
   }
@@ -188,14 +188,14 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#create-post_lists_list_id_members
    */
-  public function addMember($list_id, $email, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function addMember($list_id, $email, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
-    $parameters += array(
+    $parameters += [
       'email_address' => $email,
-    );
+    ];
 
     return $this->request('POST', '/lists/{list_id}/members', $tokens, $parameters, $batch);
   }
@@ -213,10 +213,10 @@ class MailchimpLists extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#delete-delete_lists_list_id_members_subscriber_hash
    */
   public function removeMember($list_id, $email) {
-    $tokens = array(
+    $tokens = [
       'list_id' => $list_id,
       'subscriber_hash' => md5(strtolower($email)),
-    );
+    ];
 
     return $this->request('DELETE', '/lists/{list_id}/members/{subscriber_hash}', $tokens);
   }
@@ -237,11 +237,11 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#edit-patch_lists_list_id_members_subscriber_hash
    */
-  public function updateMember($list_id, $email, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function updateMember($list_id, $email, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'list_id' => $list_id,
       'subscriber_hash' => md5(strtolower($email)),
-    );
+    ];
 
     return $this->request('PATCH', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters, $batch);
   }
@@ -262,15 +262,15 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#edit-put_lists_list_id_members_subscriber_hash
    */
-  public function addOrUpdateMember($list_id, $email, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function addOrUpdateMember($list_id, $email, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'list_id' => $list_id,
       'subscriber_hash' => md5(strtolower($email)),
-    );
+    ];
 
-    $parameters += array(
+    $parameters += [
       'email_address' => $email,
-    );
+    ];
 
     return $this->request('PUT', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters, $batch);
   }
@@ -287,10 +287,10 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#read-get_lists_list_id_segments
    */
-  public function getSegments($list_id, $parameters = array()) {
-    $tokens = array(
+  public function getSegments($list_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/segments', $tokens, $parameters);
   }
@@ -311,14 +311,14 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#create-post_lists_list_id_segments
    */
-  public function addSegment($list_id, $name, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function addSegment($list_id, $name, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
-    $parameters += array(
+    $parameters += [
       'name' => $name,
-    );
+    ];
 
     return $this->request('POST', '/lists/{list_id}/segments', $tokens, $parameters, $batch);
   }
@@ -341,15 +341,15 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#edit-patch_lists_list_id_segments_segment_id
    */
-  public function updateSegment($list_id, $segment_id, $name, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function updateSegment($list_id, $segment_id, $name, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'list_id' => $list_id,
       'segment_id' => $segment_id,
-    );
+    ];
 
-    $parameters += array(
+    $parameters += [
       'name' => $name,
-    );
+    ];
 
     return $this->request('PATCH', '/lists/{list_id}/segments/{segment_id}', $tokens, $parameters, $batch);
   }
@@ -368,11 +368,11 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/members/#read-get_lists_list_id_segments_segment_id_members
    */
-  public function getSegmentMembers($list_id, $segment_id, $parameters = array()) {
-    $tokens = array(
+  public function getSegmentMembers($list_id, $segment_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
       'segment_id' => $segment_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/segments/{segment_id}/members', $tokens, $parameters);
   }
@@ -389,10 +389,10 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/webhooks/#read-get_lists_list_id_webhooks
    */
-  public function getWebhooks($list_id, $parameters = array()) {
-    $tokens = array(
+  public function getWebhooks($list_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/webhooks', $tokens, $parameters);
   }
@@ -411,11 +411,11 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/webhooks/#read-get_lists_list_id_webhooks_webhook_id
    */
-  public function getWebhook($list_id, $webhook_id, $parameters = array()) {
-    $tokens = array(
+  public function getWebhook($list_id, $webhook_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
       'webhook_id' => $webhook_id,
-    );
+    ];
 
     return $this->request('GET', '/lists/{list_id}/webhooks/{webhook_id}', $tokens, $parameters);
   }
@@ -434,14 +434,14 @@ class MailchimpLists extends Mailchimp {
    *
    * @return object
    */
-  public function addWebhook($list_id, $url, $parameters = array(), $batch = FALSE) {
-    $tokens = array(
+  public function addWebhook($list_id, $url, $parameters = [], $batch = FALSE) {
+    $tokens = [
       'list_id' => $list_id,
-    );
+    ];
 
-    $parameters += array(
+    $parameters += [
       'url' => $url,
-    );
+    ];
 
     return $this->request('POST', '/lists/{list_id}/webhooks', $tokens, $parameters, $batch);
   }
@@ -458,11 +458,11 @@ class MailchimpLists extends Mailchimp {
    *
    * @return object
    */
-  public function deleteWebhook($list_id, $webhook_id, $parameters = array()) {
-    $tokens = array(
+  public function deleteWebhook($list_id, $webhook_id, $parameters = []) {
+    $tokens = [
       'list_id' => $list_id,
       'webhook_id' => $webhook_id,
-    );
+    ];
 
     return $this->request('DELETE', '/lists/{list_id}/webhooks/{webhook_id}', $tokens, $parameters);
   }
@@ -481,7 +481,7 @@ class MailchimpLists extends Mailchimp {
   public function getListsForEmail($email) {
     $list_data = $this->getLists();
 
-    $subscribed_lists = array();
+    $subscribed_lists = [];
 
     // Check each list for a subscriber matching the email address.
     if ($list_data->total_items > 0) {
@@ -492,11 +492,13 @@ class MailchimpLists extends Mailchimp {
           if (isset($member_data->id)) {
             $subscribed_lists[] = $list;
           }
-        } catch (MailchimpAPIException $e) {
+        }
+        catch (MailchimpAPIException $e) {
           if ($e->getCode() !== 404) {
             // 404 indicates the email address is not subscribed to this list
             // and can be safely ignored. Surface all other exceptions.
-            throw new MailchimpAPIException($e->getResponse()->getBody(), $e->getCode(), $e);
+            throw new MailchimpAPIException($e->getResponse()
+              ->getBody(), $e->getCode(), $e);
           }
         }
       }

--- a/src/MailchimpReports.php
+++ b/src/MailchimpReports.php
@@ -14,7 +14,7 @@ class MailchimpReports extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/reports/#read-get_reports
    */
-  public function getSummary($parameters = array()) {
+  public function getSummary($parameters = []) {
     return $this->request('GET', '/reports', NULL, $parameters);
   }
 
@@ -30,10 +30,10 @@ class MailchimpReports extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/reports/#read-get_reports_campaign_id
    */
-  public function getCampaignSummary($campaign_id, $parameters = array()) {
-    $tokens = array(
+  public function getCampaignSummary($campaign_id, $parameters = []) {
+    $tokens = [
       'campaign_id' => $campaign_id,
-    );
+    ];
 
     return $this->request('GET', '/reports/{campaign_id}', $tokens, $parameters);
   }

--- a/src/MailchimpTemplates.php
+++ b/src/MailchimpTemplates.php
@@ -14,7 +14,7 @@ class MailchimpTemplates extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/templates/#read-get_templates
    */
-  public function getTemplates($parameters = array()) {
+  public function getTemplates($parameters = []) {
     return $this->request('GET', '/templates', NULL, $parameters);
   }
 
@@ -30,10 +30,10 @@ class MailchimpTemplates extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/templates/#read-get_templates_template_id
    */
-  public function getTemplate($template_id, $parameters = array()) {
-    $tokens = array(
+  public function getTemplate($template_id, $parameters = []) {
+    $tokens = [
       'template_id' => $template_id,
-    );
+    ];
 
     return $this->request('GET', '/templates/{template_id}', $tokens, $parameters);
   }
@@ -50,10 +50,10 @@ class MailchimpTemplates extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/templates/default-content/#read-get_templates_template_id_default_content
    */
-  public function getTemplateContent($template_id, $parameters = array()) {
-    $tokens = array(
+  public function getTemplateContent($template_id, $parameters = []) {
+    $tokens = [
       'template_id' => $template_id,
-    );
+    ];
 
     return $this->request('GET', '/templates/{template_id}/default-content', $tokens, $parameters);
   }

--- a/tests/MailchimpCampaignsTest.php
+++ b/tests/MailchimpCampaignsTest.php
@@ -33,13 +33,13 @@ class MailchimpCampaignsTest extends \PHPUnit_Framework_TestCase {
    */
   public function testAddCampaign() {
     $type = 'regular';
-    $recipients = (object) array(
+    $recipients = (object) [
       'list_id' => '3c307a9f3f',
-    );
-    $settings = (object) array(
+    ];
+    $settings = (object) [
       'subject_line' => 'Your Purchase Receipt',
       'from_name' => 'Customer Service',
-    );
+    ];
 
     $mc = new MailchimpCampaigns();
     $mc->addCampaign($type, $recipients, $settings);
@@ -63,9 +63,9 @@ class MailchimpCampaignsTest extends \PHPUnit_Framework_TestCase {
    */
   public function testSetCampaignContent() {
     $campaign_id = '42694e9e57';
-    $parameters = array(
+    $parameters = [
       'html' => '<p>The HTML to use for the saved campaign.</p>',
-    );
+    ];
 
     $mc = new MailchimpCampaigns();
     $mc->setCampaignContent($campaign_id, $parameters);
@@ -86,13 +86,13 @@ class MailchimpCampaignsTest extends \PHPUnit_Framework_TestCase {
   public function testUpdateCampaign() {
     $campaign_id = '3e06f4ec92';
     $type = 'regular';
-    $recipients = (object) array(
+    $recipients = (object) [
       'list_id' => '3c307a9f3f',
-    );
-    $settings = (object) array(
+    ];
+    $settings = (object) [
       'subject_line' => 'This is an updated subject line',
       'from_name' => 'Customer Service',
-    );
+    ];
 
     $mc = new MailchimpCampaigns();
     $mc->updateCampaign($campaign_id, $type, $recipients, $settings);
@@ -116,9 +116,9 @@ class MailchimpCampaignsTest extends \PHPUnit_Framework_TestCase {
    */
   public function testSendTest() {
     $campaign_id = 'b03bfc273a';
-    $emails = array(
+    $emails = [
       'test@example.com',
-    );
+    ];
     $send_type = 'html';
 
     $mc = new MailchimpCampaigns();

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -120,7 +120,7 @@ class MailchimpListsTest extends \PHPUnit_Framework_TestCase {
     $mc->addMember($list_id, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);
-    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members' , $mc->getClient()->uri);
+    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members', $mc->getClient()->uri);
 
     $this->assertNotEmpty($mc->getClient()->options['json']);
 

--- a/tests/src/Client.php
+++ b/tests/src/Client.php
@@ -13,7 +13,7 @@ class Client extends \GuzzleHttp\Client {
   /**
    * @inheritdoc
    */
-  public function request($method, $uri = null, array $options = []) {
+  public function request($method, $uri = NULL, array $options = []) {
     $this->method = $method;
     $this->uri = $uri;
     $this->options = $options;

--- a/tests/src/MailchimpCampaigns.php
+++ b/tests/src/MailchimpCampaigns.php
@@ -22,23 +22,23 @@ class MailchimpCampaigns extends \Mailchimp\MailchimpCampaigns {
   /**
    * @inheritdoc
    */
-  public function getCampaign($campaign_id, $parameters = array()) {
+  public function getCampaign($campaign_id, $parameters = []) {
     parent::getCampaign($campaign_id, $parameters);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => $campaign_id,
       'type' => 'regular',
-      'recipients' => (object) array(
+      'recipients' => (object) [
         'list_id' => '57afe96172',
-      ),
-      'settings' => (object) array(
+      ],
+      'settings' => (object) [
         'subject_line' => 'Test Campaign',
-      ),
-      'tracking' => (object) array(
+      ],
+      'tracking' => (object) [
         'html_clicks' => TRUE,
         'text_clicks' => FALSE,
-      ),
-    );
+      ],
+    ];
 
     return $response;
   }

--- a/tests/src/MailchimpLists.php
+++ b/tests/src/MailchimpLists.php
@@ -22,26 +22,26 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getLists($parameters = array()) {
+  public function getLists($parameters = []) {
     parent::getLists($parameters);
 
-    $response = (object) array(
-      'lists' => array(
-        (object) array(
+    $response = (object) [
+      'lists' => [
+        (object) [
           'id' => '57afe96172',
           'name' => 'Test List One',
-        ),
-        (object) array(
+        ],
+        (object) [
           'id' => 'f4b7b26b2e',
           'name' => 'Test List Two',
-        ),
-        (object) array(
+        ],
+        (object) [
           'id' => '587693d673',
           'name' => 'Test List Three',
-        ),
-      ),
+        ],
+      ],
       'total_items' => 3,
-    );
+    ];
 
     return $response;
   }
@@ -49,13 +49,13 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getList($list_id, $parameters = array()) {
+  public function getList($list_id, $parameters = []) {
     parent::getList($list_id, $parameters);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => $list_id,
       'name' => 'Test List One',
-    );
+    ];
 
     return $response;
   }
@@ -63,20 +63,20 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getInterestCategories($list_id, $parameters = array()) {
+  public function getInterestCategories($list_id, $parameters = []) {
     parent::getInterestCategories($list_id, $parameters);
 
-    $response = (object) array(
+    $response = (object) [
       'list_id' => $list_id,
-      'categories' => array(
-        (object) array(
+      'categories' => [
+        (object) [
           'list_id' => $list_id,
           'id' => 'a1e9f4b7f6',
           'title' => 'Test Interest Category',
-        ),
-      ),
+        ],
+      ],
       'total_items' => 1,
-    );
+    ];
 
     return $response;
   }
@@ -84,20 +84,20 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getInterests($list_id, $interest_category_id, $parameters = array()) {
+  public function getInterests($list_id, $interest_category_id, $parameters = []) {
     parent::getInterests($list_id, $interest_category_id, $parameters);
 
-    $response = (object) array(
-      'interests' => array(
-        (object) array(
+    $response = (object) [
+      'interests' => [
+        (object) [
           'category_id' => $interest_category_id,
           'list_id' => $list_id,
           'id' => '9143cf3bd1',
           'name' => 'Test Interest',
-        ),
-      ),
+        ],
+      ],
       'total_items' => 1,
-    );
+    ];
 
     return $response;
   }
@@ -105,24 +105,24 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getMergeFields($list_id, $parameters = array()) {
+  public function getMergeFields($list_id, $parameters = []) {
     parent::getMergeFields($list_id, $parameters);
 
-    $response = (object) array(
-      'merge_fields' => array(
-        (object) array(
+    $response = (object) [
+      'merge_fields' => [
+        (object) [
           'merge_id' => 1,
           'tag' => 'FNAME',
           'list_id' => $list_id,
-        ),
-        (object) array(
+        ],
+        (object) [
           'merge_id' => 2,
           'tag' => 'LNAME',
           'list_id' => $list_id,
-        ),
-      ),
+        ],
+      ],
       'total_items' => 2,
-    );
+    ];
 
     return $response;
   }
@@ -130,14 +130,14 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getMemberInfo($list_id, $email, $parameters = array()) {
+  public function getMemberInfo($list_id, $email, $parameters = []) {
     parent::getMemberInfo($list_id, $email, $parameters);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => md5(strtolower($email)),
       'email_address' => $email,
       'status' => 'subscribed',
-    );
+    ];
 
     return $response;
   }
@@ -145,13 +145,13 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function addMember($list_id, $email, $parameters = array(), $batch = FALSE) {
+  public function addMember($list_id, $email, $parameters = [], $batch = FALSE) {
     parent::addMember($list_id, $email, $parameters, $batch);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => md5(strtolower($email)),
       'email_address' => $email,
-    );
+    ];
 
     foreach ($parameters as $key => $value) {
       $response->{$key} = $value;
@@ -170,13 +170,13 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function updateMember($list_id, $email, $parameters = array(), $batch = FALSE) {
+  public function updateMember($list_id, $email, $parameters = [], $batch = FALSE) {
     parent::updateMember($list_id, $email, $parameters, $batch);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => md5(strtolower($email)),
       'email_address' => $email,
-    );
+    ];
 
     foreach ($parameters as $key => $value) {
       $response->{$key} = $value;
@@ -188,13 +188,13 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function addOrUpdateMember($list_id, $email, $parameters = array(), $batch = FALSE) {
+  public function addOrUpdateMember($list_id, $email, $parameters = [], $batch = FALSE) {
     parent::addOrUpdateMember($list_id, $email, $parameters, $batch);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => md5(strtolower($email)),
       'email_address' => $email,
-    );
+    ];
 
     foreach ($parameters as $key => $value) {
       $response->{$key} = $value;
@@ -206,26 +206,26 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getSegments($list_id, $parameters = array()) {
+  public function getSegments($list_id, $parameters = []) {
     parent::getSegments($list_id, $parameters);
 
-    $response = (object) array(
-      'segments' => array(
-        (object) array(
+    $response = (object) [
+      'segments' => [
+        (object) [
           'id' => 49377,
           'name' => 'Test Segment One',
           'type' => 'static',
           'list_id' => $list_id,
-        ),
-        (object) array(
+        ],
+        (object) [
           'id' => 49378,
           'name' => 'Test Segment Two',
           'type' => 'static',
           'list_id' => $list_id,
-        ),
-      ),
+        ],
+      ],
       'total_items' => 2,
-    );
+    ];
 
     return $response;
   }
@@ -233,10 +233,10 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function addSegment($list_id, $name, $parameters = array(), $batch = FALSE) {
+  public function addSegment($list_id, $name, $parameters = [], $batch = FALSE) {
     parent::addSegment($list_id, $name, $parameters, $batch);
 
-    $response = (object) array();
+    $response = (object) [];
 
     if (!empty($list_id) && !empty($name) && !empty($parameters['type'])) {
       $response->id = 49381;
@@ -251,15 +251,15 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function updateSegment($list_id, $segment_id, $name, $parameters = array(), $batch = FALSE) {
+  public function updateSegment($list_id, $segment_id, $name, $parameters = [], $batch = FALSE) {
     parent::updateSegment($list_id, $segment_id, $name, $parameters);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => $segment_id,
       'name' => $name,
       'member_count' => (isset($parameters['static_segment'])) ? count($parameters['static_segment']) : 0,
       'list_id' => $list_id,
-    );
+    ];
 
     return $response;
   }
@@ -267,27 +267,27 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function getWebhooks($list_id, $parameters = array()) {
+  public function getWebhooks($list_id, $parameters = []) {
     parent::getWebhooks($list_id, $parameters);
 
-    $response = (object) array(
-      'webhooks' => array(
-        (object) array(
+    $response = (object) [
+      'webhooks' => [
+        (object) [
           'id' => '37b9c73a88',
           'url' => 'http://example.org',
-          'events' => (object) array(
+          'events' => (object) [
             'subscribe' => TRUE,
             'unsubscribe' => FALSE,
-          ),
-          'sources' => (object) array(
+          ],
+          'sources' => (object) [
             'user' => TRUE,
             'api' => FALSE,
-          ),
+          ],
           'list_id' => $list_id,
-        ),
-      ),
+        ],
+      ],
       'total_items' => 1,
-    );
+    ];
 
     return $response;
   }
@@ -295,14 +295,14 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function addWebhook($list_id, $url, $parameters = array(), $batch = FALSE) {
+  public function addWebhook($list_id, $url, $parameters = [], $batch = FALSE) {
     parent::addWebhook($list_id, $url, $parameters, $batch);
 
-    $response = (object) array(
+    $response = (object) [
       'id' => 'ab24521a00',
       'url' => $url,
       'list_id' => $list_id,
-    );
+    ];
 
     foreach ($parameters as $key => $value) {
       $response->{$key} = $value;
@@ -314,7 +314,7 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function deleteWebhook($list_id, $webhook_id, $parameters = array()) {
+  public function deleteWebhook($list_id, $webhook_id, $parameters = []) {
     parent::deleteWebhook($list_id, $webhook_id, $parameters);
 
     return (!empty($list_id) && !empty($webhook_id));


### PR DESCRIPTION
I refactored the entire code base with PHPStorm. This converted all arrays to the short array syntax. A few try/catch's were changed so that the } before the catch is on a new line. And there was a space here and there before a comma. I use Drupal coding standards for the refactoring. This commit resolves #7 