### PR TITLE
Added support for segment members resource

### DIFF
--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -378,6 +378,35 @@ class MailchimpLists extends Mailchimp {
   }
 
   /**
+   * Adds a member to a list segment.
+   *
+   * @param string $list_id
+   *   The ID of the list.
+   * @param string $segment_id
+   *   The ID of the segment.
+   * @param array $email
+   *   The email address to add to the segment.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/members/
+   */
+  public function addSegmentMember($list_id, $segment_id, $email, $parameters = []) {
+    $tokens = [
+      'list_id' => $list_id,
+      'segment_id' => $segment_id,
+    ];
+
+    $parameters += [
+      'email_address' => $email,
+    ];
+
+    return $this->request('POST', '/lists/{list_id}/segments/{segment_id}/members', $tokens, $parameters);
+  }
+
+  /**
    * Gets information about webhooks associated with a list.
    *
    * @param string $list_id


### PR DESCRIPTION
As I described in [this issue](https://github.com/thinkshout/mailchimp-api-php/issues/22), I'm unable to get updateSegment to work to add a subscriber to a static segment. This is true if I call the API directly, as well as if I call the Drupal mailchimp module's `mailchimp_segment_add_subscriber` method. I haven't created an issue or patch on D.O. for this, though I will if you would like me to. 

However, the functionality in this pull request does fix the issue for me and I'm able to add subscribers to a static segment. I have not yet added tests for this. Please take a look and let me know if you have questions or input. Thanks.