### PR TITLE
Allow passing arbitrary options to the http client

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -94,10 +94,10 @@ class Mailchimp {
    *   The MailChimp API key.
    * @param string $api_user
    *   The MailChimp API username.
-   * @param int $timeout
-   *   Maximum request time in seconds.
+   * @param array $http_options
+   *   HTTP client options.
    */
-  public function __construct($api_key, $api_user = 'apikey', $timeout = 10) {
+  public function __construct($api_key, $api_user = 'apikey', $http_options = null) {
     $this->api_key = $api_key;
     $this->api_user = $api_user;
 
@@ -105,9 +105,19 @@ class Mailchimp {
 
     $this->endpoint = str_replace(Mailchimp::DEFAULT_DATA_CENTER, $dc, $this->endpoint);
 
-    $this->client = new Client([
-      'timeout' => $timeout,
-    ]);
+    // Handle deprecated 'timeout' argument.
+    if (is_int($http_options)) {
+      $http_options = [
+        'timeout' => $http_options,
+      ];
+    }
+
+    // Default timeout is 10 seconds.
+    $http_options += [
+      'timeout' => 10,
+    ];
+
+    $this->client = new Client($http_options);
   }
 
   /**

--- a/tests/src/Mailchimp.php
+++ b/tests/src/Mailchimp.php
@@ -12,7 +12,7 @@ class Mailchimp extends \Mailchimp\Mailchimp {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $timeout = 60) {
+  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = null) {
     $this->client = new Client();
   }
 

--- a/tests/src/MailchimpAutomations.php
+++ b/tests/src/MailchimpAutomations.php
@@ -7,7 +7,7 @@ class MailchimpAutomations extends \Mailchimp\MailchimpAutomations {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $timeout = 60) {
+  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = null) {
     $this->client = new Client();
   }
 

--- a/tests/src/MailchimpCampaigns.php
+++ b/tests/src/MailchimpCampaigns.php
@@ -12,7 +12,7 @@ class MailchimpCampaigns extends \Mailchimp\MailchimpCampaigns {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $timeout = 60) {
+  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = null) {
     $this->client = new Client();
   }
 

--- a/tests/src/MailchimpEcommerce.php
+++ b/tests/src/MailchimpEcommerce.php
@@ -35,7 +35,7 @@ class MailchimpEcommerce extends \Mailchimp\MailchimpEcommerce {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $timeout = 60) {
+  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = null) {
     $this->client = new Client();
   }
 

--- a/tests/src/MailchimpLists.php
+++ b/tests/src/MailchimpLists.php
@@ -12,7 +12,7 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $timeout = 60) {
+  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = null) {
     $this->client = new Client();
   }
 

--- a/tests/src/MailchimpReports.php
+++ b/tests/src/MailchimpReports.php
@@ -12,7 +12,7 @@ class MailchimpReports extends \Mailchimp\MailchimpReports {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $timeout = 60) {
+  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = null) {
     $this->client = new Client();
   }
 

--- a/tests/src/MailchimpTemplates.php
+++ b/tests/src/MailchimpTemplates.php
@@ -12,7 +12,7 @@ class MailchimpTemplates extends \Mailchimp\MailchimpTemplates {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $timeout = 60) {
+  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = null) {
     $this->client = new Client();
   }
 


### PR DESCRIPTION
This change is backwards compatible. Constructing a Mailchimp object was
previously done this way:

    new Mailchimp($key, $user, $timeout);

This commit introduces a more flexible approach:

    new Mailchimp($key, $user, $http_options);

For backwards compatibility, $http_options can be an integer indicating
the desired request timeout.

If $http_options is an array without a 'timeout' element, the default
timeout of 10 seconds is added to the http options. Otherwise the
options are passed verbatim to the guzzle Client constructor.

Typical options a user of this library might want to pass to the http
client are debug settings, proxies, connection timeouts or ssl options.

Fixes #32.