### PR TITLE
loosen guzzle version dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/thinkshout/mailchimp-api-php",
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "6.2.1"
+    "guzzlehttp/guzzle": "^6.2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.21"


### PR DESCRIPTION
While this library uses an exact constraint, any patches or updates on Guzzle cannot be automatically installed by composer. A caret in the version constraint allows any version of Guzzle 6. https://getcomposer.org/doc/articles/versions.md#caret