### PR TITLE
Allow recent versions of PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "guzzlehttp/guzzle": "^6.2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.21"
+    "phpunit/phpunit": "^4.8.21"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The version of PHPUnit specified in the composer.json seems to be unnecessarily restrictive, is there a reason that it's pegged to 4.8.21 specifically?