### PR TITLE
Fix #58

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -277,13 +277,15 @@ class Mailchimp {
    *   TRUE if this request should be added to pending batch operations.
    * @param bool $returnAssoc
    *   TRUE to return MailChimp API response as an associative array.
+   * @param bool $object
+   *   FALSE to prevent converting the parameters to a stdObject.
    *
    * @return mixed
    *   Object or Array if $returnAssoc is TRUE.
    *
    * @throws MailchimpAPIException
    */
-  public function request($method, $path, $tokens = NULL, $parameters = NULL, $batch = FALSE, $returnAssoc = FALSE) {
+  public function request($method, $path, $tokens = NULL, $parameters = NULL, $batch = FALSE, $returnAssoc = FALSE, $object = TRUE) {
     if (!empty($tokens)) {
       foreach ($tokens as $key => $value) {
         $path = str_replace('{' . $key . '}', $value, $path);
@@ -307,10 +309,10 @@ class Mailchimp {
     }
 
     if ($this->use_curl) {
-      return $this->handleRequestCURL($method, $this->endpoint . $path, $options, $parameters, $returnAssoc);
+      return $this->handleRequestCURL($method, $this->endpoint . $path, $options, $parameters, $returnAssoc, $object);
     }
     else {
-      return $this->handleRequest($method, $this->endpoint . $path, $options, $parameters, $returnAssoc);
+      return $this->handleRequest($method, $this->endpoint . $path, $options, $parameters, $returnAssoc, $object);
     }
   }
 
@@ -319,7 +321,7 @@ class Mailchimp {
    *
    * @see Mailchimp::request()
    */
-  public function handleRequest($method, $uri = '', $options = [], $parameters = [], $returnAssoc = FALSE) {
+  public function handleRequest($method, $uri = '', $options = [], $parameters = [], $returnAssoc = FALSE, $object = TRUE) {
     if (!empty($parameters)) {
       if ($method == 'GET') {
         // Send parameters as query string parameters.
@@ -327,7 +329,11 @@ class Mailchimp {
       }
       else {
         // Send parameters as JSON in request body.
-        $options['json'] = (object) $parameters;
+        if ($object) {
+          $options['json'] = (object) $parameters;
+        } else {
+          $options['json'] = $parameters;
+        }
       }
     }
 

--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -387,8 +387,6 @@ class MailchimpLists extends Mailchimp {
    *   The ID of the list.
    * @param int $segment_id
    *   The ID of the segment.
-   * @param string $name
-   *   The name of the segment.
    * @param array $parameters
    *   Associative array of optional request parameters.
    * @param bool $batch
@@ -398,17 +396,13 @@ class MailchimpLists extends Mailchimp {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/#edit-patch_lists_list_id_segments_segment_id
    */
-  public function updateSegment($list_id, $segment_id, $name, $parameters = [], $batch = FALSE) {
+  public function updateSegment($list_id, $segment_id, $parameters = [], $batch = FALSE) {
     $tokens = [
       'list_id' => $list_id,
       'segment_id' => $segment_id,
     ];
 
-    $parameters += [
-      'name' => $name,
-    ];
-
-    return $this->request('PATCH', '/lists/{list_id}/segments/{segment_id}', $tokens, $parameters, $batch);
+    return $this->request('POST', '/lists/{list_id}/segments/{segment_id}', $tokens, $parameters, $batch, FALSE, FALSE);
   }
 
   /**

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -249,19 +249,23 @@ class MailchimpListsTest extends \PHPUnit_Framework_TestCase {
   public function testUpdateSegment() {
     $list_id = '57afe96172';
     $segment_id = '49381';
-    $name = 'Updated Test Segment';
+    $emails = array(
+      'members_to_add' => array(
+        'new-employee@mailchimp.com'
+      )
+    );
 
     $mc = new MailchimpLists();
-    $mc->updateSegment($list_id, $segment_id, $name);
+    $mc->updateSegment($list_id, $segment_id, $emails);
 
-    $this->assertEquals('PATCH', $mc->getClient()->method);
+    $this->assertEquals('POST', $mc->getClient()->method);
     $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/segments/' . $segment_id, $mc->getClient()->uri);
 
     $this->assertNotEmpty($mc->getClient()->options['json']);
 
     $request_body = $mc->getClient()->options['json'];
 
-    $this->assertEquals($name, $request_body->name);
+    $this->assertEquals('new-employee@mailchimp.com', $request_body['members_to_add'][0]);
   }
 
   /**


### PR DESCRIPTION
This will allow users to use Views Bulk Operations to add subscribed members to an already-created static segment.

A subsequent mailchimp_lists.module patch for adding users will appear on drupal.org.