### PR TITLE
Add removeSegmentMember API support and test

### DIFF
--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -490,6 +490,30 @@ class MailchimpLists extends Mailchimp {
   }
 
   /**
+   * Removes a member from a list segment.
+   *
+   * @param string $list_id
+   *   The ID of the list.
+   * @param string $segment_id
+   *   The ID of the segment.
+   * @param array $email
+   *   The email address to remove from the segment.
+   *
+   * @return object
+   *
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/members/#delete-delete_lists_list_id_segments_segment_id_members_subscriber_hash
+   */
+  public function removeSegmentMember($list_id, $segment_id, $email) {
+    $tokens = [
+      'list_id' => $list_id,
+      'segment_id' => $segment_id,
+      'subscriber_hash' => md5(strtolower($email)),
+    ];
+
+    return $this->request('DELETE', '/lists/{list_id}/segments/{segment_id}/members/{subscriber_hash}', $tokens);
+  }
+
+  /**
    * Gets information about webhooks associated with a list.
    *
    * @param string $list_id

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -301,4 +301,19 @@ class MailchimpListsTest extends TestCase {
     $this->assertEquals($email, $request_body->email_address);
   }
 
+  /**
+   * Tests library functionality for removing a segment member.
+   */
+  public function testRemoveSegmentMember() {
+    $list_id = '205d96e6b4';
+    $segment_id = '457';
+    $email = 'test@example.com';
+
+    $mc = new MailchimpLists();
+    $mc->removeSegmentMember($list_id, $segment_id, $email);
+
+    $this->assertEquals('DELETE', $mc->getClient()->method);
+    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/segments/' . $segment_id . '/members/' . md5($email), $mc->getClient()->uri);
+  }
+
 }


### PR DESCRIPTION
Please consider adding support for removing members from list segments. New test passes (though there is a pre-existing failure with MailchimpEcommerce::addStore). Feedback welcome. Thanks!