### PR TITLE
 Allow Guzzle middleware by having client as constructor argument

### DIFF
--- a/src/http/MailchimpGuzzleHttpClient.php
+++ b/src/http/MailchimpGuzzleHttpClient.php
@@ -3,6 +3,7 @@
 namespace Mailchimp\http;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use Mailchimp\MailchimpAPIException;
 
@@ -27,8 +28,8 @@ class MailchimpGuzzleHttpClient implements MailchimpHttpClientInterface {
    *   Guzzle HTTP configuration options.
    *   Currently supports only 'timeout'.
    */
-  public function __construct($config = []) {
-    $this->guzzle = new Client($config);
+  public function __construct($config = [], ClientInterface $client = null) {
+    $this->guzzle = $client ? $client : new Client($config);
   }
 
   /**


### PR DESCRIPTION
... and apply dependency inversion principle by relying on interface.

Right now it is not possible to pass a Guzzle client. Because of that, the Guzzle middleware can not get used.