### PR TITLE
Added method addTagsMember() to MailchimpLists.

### DIFF
--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -490,6 +490,34 @@ class MailchimpLists extends Mailchimp {
   }
 
   /**
+   * Adds tags to a member.
+   *
+   * @param string $list_id
+   *   The ID of the list.
+   * @param string[] $tags
+   *   A list of tags to add.
+   * @param array $email
+   *   The email address to add the tag to.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   */
+  public function addTagsMember($list_id, array $tags, $email, array $parameters = []) {
+    $tokens = [
+      'list_id' => $list_id,
+      'subscriber_hash' => md5($email),
+    ];
+
+    foreach ($tags as $tag) {
+      $parameters['tags'][] = [
+        'name' => $tag,
+        'status' => 'active',
+      ];
+    }
+
+    return $this->request('POST', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
+  }
+
+  /**
    * Gets information about webhooks associated with a list.
    *
    * @param string $list_id

--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -504,7 +504,7 @@ class MailchimpLists extends Mailchimp {
   public function addTagsMember($list_id, array $tags, $email, array $parameters = []) {
     $tokens = [
       'list_id' => $list_id,
-      'subscriber_hash' => md5($email),
+      'subscriber_hash' => md5(strtolower($email)),
     ];
 
     foreach ($tags as $tag) {

--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -522,6 +522,38 @@ class MailchimpLists extends Mailchimp {
   }
 
   /**
+   * Removes tags from a member.
+   *
+   * @param string $list_id
+   *   The ID of the list.
+   * @param string[] $tags
+   *   A list of tags to remove.
+   * @param array $email
+   *   The email address to remove the tag from.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/
+   */
+  public function removeTagsMember($list_id, array $tags, $email, array $parameters = []) {
+    $tokens = [
+      'list_id' => $list_id,
+      'subscriber_hash' => md5(strtolower($email)),
+    ];
+
+    foreach ($tags as $tag) {
+      $parameters['tags'][] = [
+        'name' => $tag,
+        'status' => 'inactive',
+      ];
+    }
+
+    return $this->request('POST', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
+  }
+
+  /**
    * Gets information about webhooks associated with a list.
    *
    * @param string $list_id

--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -500,6 +500,10 @@ class MailchimpLists extends Mailchimp {
    *   The email address to add the tag to.
    * @param array $parameters
    *   Associative array of optional request parameters.
+   *
+   * @return object
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/
    */
   public function addTagsMember($list_id, array $tags, $email, array $parameters = []) {
     $tokens = [

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -301,4 +301,34 @@ class MailchimpListsTest extends TestCase {
     $this->assertEquals($email, $request_body->email_address);
   }
 
+  /**
+   * Tests library functionality for adding tags to a member.
+   */
+  public function testAddTagsMember() {
+    $list_id = '205d96e6b4';
+    $tags = ['Foo', 'Bar'];
+    $email = 'test@example.com';
+    $mc = new MailchimpLists();
+    $mc->addTagsMember($list_id, $tags, $email);
+
+    $this->assertEquals('POST', $mc->getClient()->method);
+    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members/' . md5($email) . '/tags', $mc->getClient()->uri);
+
+    $this->assertNotEmpty($mc->getClient()->options['json']);
+
+    $request_body = $mc->getClient()->options['json'];
+
+    $expected = [
+      [
+        'name' => 'Foo',
+        'status' => 'active',
+      ],
+      [
+        'name' => 'Bar',
+        'status' => 'active',
+      ],
+    ];
+    $this->assertEquals($expected, $request_body->tags);
+  }
+
 }

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -331,4 +331,34 @@ class MailchimpListsTest extends TestCase {
     $this->assertEquals($expected, $request_body->tags);
   }
 
+  /**
+   * Tests library functionality for removing tags from a member.
+   */
+  public function testRemoveTagsMember() {
+    $list_id = '205d96e6b4';
+    $tags = ['Foo', 'Bar'];
+    $email = 'test@example.com';
+    $mc = new MailchimpLists();
+    $mc->removeTagsMember($list_id, $tags, $email);
+
+    $this->assertEquals('POST', $mc->getClient()->method);
+    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members/' . md5($email) . '/tags', $mc->getClient()->uri);
+
+    $this->assertNotEmpty($mc->getClient()->options['json']);
+
+    $request_body = $mc->getClient()->options['json'];
+
+    $expected = [
+      [
+        'name' => 'Foo',
+        'status' => 'inactive',
+      ],
+      [
+        'name' => 'Bar',
+        'status' => 'inactive',
+      ],
+    ];
+    $this->assertEquals($expected, $request_body->tags);
+  }
+
 }


### PR DESCRIPTION
It would be useful to have a method to add tags to a member.

See https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/