### PR TITLE
Add promo rules and promo codes to ecommerce

### DIFF
--- a/src/MailchimpEcommerce.php
+++ b/src/MailchimpEcommerce.php
@@ -1025,4 +1025,282 @@ class MailchimpEcommerce extends Mailchimp {
     return $this->request('DELETE', '/ecommerce/stores/{store_id}/products/{product_id}/variants/{variant_id}', $tokens);
   }
 
+  /**
+   * Get information about a store's promo rules.
+   *
+   * @param string $store_id
+   *   The ID of the store.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *   The API customer response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/#read-get_ecommerce_stores_store_id_promo_rules
+   */
+  public function getPromoRules($store_id, $parameters = []) {
+    $tokens = [
+      'store_id' => $store_id,
+    ];
+
+    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules', $tokens, $parameters);
+  }
+
+  /**
+   * Get information about a promo rule.
+   *
+   * @param string $store_id
+   *   The store ID.
+   * @param string $promo_rule_id
+   *   The id for the promo rule of a store.
+   * @param array $parameters
+   *   An array of optional parameters. See API docs.
+   *
+   * @return object
+   *   The API promo rule response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/#read-get_ecommerce_stores_store_id_promo_rules_promo_rule_id
+   */
+  public function getPromoRule($store_id, $promo_rule_id, $parameters = []) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule_id,
+    ];
+    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens, $parameters);
+  }
+
+  /**
+   * Adds a new a promo rule to a store.
+   *
+   * @param string $store_id
+   *   The store ID.
+   * @param array $promo_rule
+   *   An associative array of promo rule information.
+   *   - id (string) A unique identifier for the promo rule.
+   *   - description (string) A description of the promo rule
+   *   - amount (number) The amount of the promo code discount.
+   *       If ‘type’ is ‘fixed’, the amount is treated as a monetary value.
+   *       If ‘type’ is ‘percentage’, amount must be a decimal value between
+   *       0.0 and 1.0, inclusive.
+   *   - type (string) Type of discount. For free shipping, set to fixed.
+   *       Possible values: fixed, percentage
+   *   - target (string) The target that the discount applies to. Possible
+   *       values: per_item, total, shipping
+   *
+   * @return object
+   *   The API promo rule response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/#create-post_ecommerce_stores_store_id_promo_rules
+   */
+  public function addPromoRule($store_id, $promo_rule) {
+    $tokens = [
+      'store_id' => $store_id,
+    ];
+    return $this->request('POST', '/ecommerce/stores/{store_id}/promo-rules', $tokens, $promo_rule);
+  }
+
+  /**
+   * Update a promo rule.
+   *
+   * @param string $store_id
+   *   The ID of the store.
+   * @param array $promo_rule
+   *   An associative array of promo rule information.
+   *   - id (string) A unique identifier for the promo rule.
+   *   - description (string) A description of the promo rule
+   *   - amount (number) The amount of the promo code discount.
+   *       If ‘type’ is ‘fixed’, the amount is treated as a monetary value.
+   *       If ‘type’ is ‘percentage’, amount must be a decimal value between
+   *       0.0 and 1.0, inclusive.
+   *   - type (string) Type of discount. For free shipping, set to fixed.
+   *       Possible values: fixed, percentage
+   *   - target (string) The target that the discount applies to. Possible
+   *       values: per_item, total, shipping
+   * @param bool $batch
+   *   TRUE to create a new pending batch operation.
+   *
+   * @return object
+   *   The API promo rule response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/#edit-patch_ecommerce_stores_store_id_promo_rules_promo_rule_id
+   */
+  public function updatePromoRule($store_id, $promo_rule, $batch = FALSE) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule['id'],
+    ];
+
+    return $this->request('PATCH', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens, $promo_rule, $batch);
+  }
+
+  /**
+   * Delete a promo rule.
+   * @param string $store_id
+   *   The ID of the store.
+   * @param string $promo_rule_id
+   *   The ID of the promo rule.
+   *
+   * @return object
+   *   The API customer response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/#delete-delete_ecommerce_stores_store_id_promo_rules_promo_rule_id
+   */
+  public function deletePromoRule($store_id, $promo_rule_id) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule_id,
+    ];
+
+    return $this->request('DELETE', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens);
+  }
+
+  /**
+   * Get information about a store's promo codes.
+   *
+   * @param string $store_id
+   *   The ID of the store.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *   The API customer response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/promo-codes/#read-get_ecommerce_stores_store_id_promo_rules_promo_rule_id_promo_codes
+   */
+  public function getPromoCodes($store_id, $promo_rule_id, $parameters = []) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule_id,
+    ];
+
+    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes', $tokens, $parameters);
+  }
+
+  /**
+   * Get information about a promo code.
+   *
+   * @param string $store_id
+   *   The store ID.
+   * @param string $promo_rule_id
+   *   The id for the promo rule of a store.
+   * @param array $parameters
+   *   An array of optional parameters. See API docs.
+   *
+   * @return object
+   *   The API promo rule response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/promo-codes/#read-get_ecommerce_stores_store_id_promo_rules_promo_rule_id_promo_codes_promo_code_id
+   */
+  public function getPromoCode($store_id, $promo_rule_id, $promo_code_id, $parameters = []) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule_id,
+      'promo_code_id' => $promo_code_id,
+    ];
+    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens, $parameters);
+  }
+
+  /**
+   * Adds a new a promo code to a store.
+   *
+   * @param string $store_id
+   *   The store ID.
+   * @param string $promo_rule_id
+   *   The promo rule ID.
+   * @param array $promo_code
+   *   An associative array of promo code information.
+   *   - id (string) A unique identifier for the promo code.
+   *   - code (string) The discount code.
+   *   - redemption_url (string) The url that should be used in the promotion
+   *       campaign.
+   *
+   * @return object
+   *   The API promo rule response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/promo-codes/#create-post_ecommerce_stores_store_id_promo_rules_promo_rule_id_promo_codes
+   */
+  public function addPromoCode($store_id, $promo_rule_id, $promo_code) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule_id,
+      'promo_code_id' => $promo_code['id'],
+    ];
+    return $this->request('POST', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens, $promo_code);
+  }
+
+  /**
+   * Update a promo code.
+   *
+   * @param string $store_id
+   *   The ID of the store.
+   * @param string $promo_rule_id
+   *   The promo rule ID.
+   * @param array $promo_code
+   *   An associative array of promo code information.
+   *   - id (string) A unique identifier for the promo code.
+   *   - code (string) The discount code.
+   *   - redemption_url (string) The url that should be used in the promotion
+   *       campaign.
+   * @param bool $batch
+   *   TRUE to create a new pending batch operation.
+   *
+   * @return object
+   *   The API promo rule response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/promo-codes/#edit-patch_ecommerce_stores_store_id_promo_rules_promo_rule_id_promo_codes_promo_code_id
+   */
+  public function updatePromoCode($store_id, $promo_rule_id, $promo_code, $batch = FALSE) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule_id,
+      'promo_code_id' => $promo_code['id'],
+    ];
+
+    return $this->request('PATCH', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens, $promo_code, $batch);
+  }
+
+  /**
+   * Delete a promo code.
+   *
+   * @param string $store_id
+   *   The ID of the store.
+   * @param string $promo_rule_id
+   *   The ID of the promo rule.
+   * @param string $promo_code_id
+   *   The ID of the promo code.
+   *
+   * @return object
+   *   The API customer response object.
+   *
+   * @throws \Mailchimp\MailchimpAPIException
+   *
+   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/promo-rules/promo-codes/#delete-delete_ecommerce_stores_store_id_promo_rules_promo_rule_id_promo_codes_promo_code_id
+   */
+  public function deletePromoCode($store_id, $promo_rule_id, $promo_code_id) {
+    $tokens = [
+      'store_id' => $store_id,
+      'promo_rule_id' => $promo_rule_id,
+      'promo_code_id' => $promo_code_id,
+    ];
+
+    return $this->request('DELETE', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens);
+  }
 }

--- a/tests/MailchimpEcommerceTest.php
+++ b/tests/MailchimpEcommerceTest.php
@@ -751,4 +751,196 @@ class MailchimpEcommerceTest extends TestCase {
     $this->assertEquals($params['sku'], $request_body->sku);
   }
 
+
+  /**
+   * Tests creating a promo rule
+   */
+  public function testAddPromoRule() {
+    $store_id = 'MC001';
+    $params = [
+      'id' => 'promo0001',
+      'description' => 'Test promotion rule',
+      'amount' => '10.00',
+      'type' => 'fixed',
+      'target' => 'total',
+    ];
+    $mc = new MailchimpEcommerce();
+    $mc->addPromoRule($store_id, $params);
+    // Check method.
+    $this->assertEquals('POST', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules', $mc->getClient()->uri);
+    // Test the contents of the body of the request for the params.
+    $this->assertNotEmpty($mc->getClient()->options['json']);
+    $request_body = $mc->getClient()->options['json'];
+    $this->assertEquals($params['id'], $request_body->id);
+    $this->assertEquals($params['description'], $request_body->description);
+    $this->assertEquals($params['amount'], $request_body->amount);
+    $this->assertEquals($params['type'], $request_body->type);
+    $this->assertEquals($params['target'], $request_body->target);
+  }
+
+  /**
+   * Tests updating a promo rule
+   */
+  public function testUpdatePromoRule() {
+    $store_id = 'MC001';
+    $params = [
+      'id' => 'promo0001',
+      'description' => 'New description',
+      'amount' => '11',
+      'type' => 'percentage',
+      'target' => 'per_item',
+    ];
+    $mc = new MailchimpEcommerce();
+    $mc->updatePromoRule($store_id, $params);
+    // Check method.
+    $this->assertEquals('PATCH', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $params['id'], $mc->getClient()->uri);
+    // Test the contents of the body of the request for the params.
+    $this->assertNotEmpty($mc->getClient()->options['json']);
+    $request_body = $mc->getClient()->options['json'];
+    $this->assertEquals($params['id'], $request_body->id);
+    $this->assertEquals($params['description'], $request_body->description);
+    $this->assertEquals($params['amount'], $request_body->amount);
+    $this->assertEquals($params['type'], $request_body->type);
+    $this->assertEquals($params['target'], $request_body->target);
+  }
+
+  /**
+   * Tests getting promo rules
+   */
+  public function testGetPromoRules() {
+    $store_id = 'MC001';
+    $mc = new MailchimpEcommerce();
+    $mc->getPromoRules($store_id);
+    // Check method.
+    $this->assertEquals('GET', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules', $mc->getClient()->uri);
+  }
+
+  /**
+   * Tests getting a promo rule
+   */
+  public function testGetPromoRule() {
+    $store_id = 'MC001';
+    $promo_rule_id = 'promo0001';
+    $mc = new MailchimpEcommerce();
+    $mc->getPromoRule($store_id, $promo_rule_id);
+    // Check method.
+    $this->assertEquals('GET', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $promo_rule_id, $mc->getClient()->uri);
+  }
+
+  /**
+   * Tests deleting a promo rule
+   */
+  public function testDeletePromoRule() {
+    $store_id = 'MC001';
+    $promo_rule_id = 'promo0001';
+    $mc = new MailchimpEcommerce();
+    $mc->deletePromoRule($store_id, $promo_rule_id);
+    // Method must be DELETE.
+    $this->assertEquals('DELETE', $mc->getClient()->method);
+    // Confirm URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $promo_rule_id, $mc->getClient()->uri);
+  }
+
+  /**
+   * Tests creating a promo code
+   */
+  public function testAddPromoCode() {
+    $store_id = 'MC001';
+    $promo_rule_id = 'promo0001';
+    $promo_code_id = 'code001';
+    $params = [
+      'id' => 'code001',
+      'code' => 'abc0042',
+      'redemption_url' => 'http://www.example.com',
+    ];
+    $mc = new MailchimpEcommerce();
+    $mc->addPromoCode($store_id, $promo_rule_id, $params);
+    // Check method.
+    $this->assertEquals('POST', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $promo_rule_id . '/promo-codes/' . $promo_code_id, $mc->getClient()->uri);
+    // Test the contents of the body of the request for the params.
+    $this->assertNotEmpty($mc->getClient()->options['json']);
+    $request_body = $mc->getClient()->options['json'];
+    $this->assertEquals($params['id'], $request_body->id);
+    $this->assertEquals($params['code'], $request_body->code);
+    $this->assertEquals($params['redemption_url'], $request_body->redemption_url);  }
+
+  /**
+   * Tests updating a promo code
+   */
+  public function testUpdatePromoCode() {
+    $store_id = 'MC001';
+    $promo_rule_id = 'promo0001';
+    $params = [
+      'id' => 'code001',
+      'code' => 'abc0042',
+      'redemption_url' => 'http://www.example.com',
+    ];
+    $mc = new MailchimpEcommerce();
+    $mc->updatePromoCode($store_id, $promo_rule_id, $params);
+    // Check method.
+    $this->assertEquals('PATCH', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $promo_rule_id . '/promo-codes/' . $params['id'], $mc->getClient()->uri);
+    // Test the contents of the body of the request for the params.
+    $this->assertNotEmpty($mc->getClient()->options['json']);
+    $request_body = $mc->getClient()->options['json'];
+    $this->assertEquals($params['id'], $request_body->id);
+    $this->assertEquals($params['code'], $request_body->code);
+    $this->assertEquals($params['redemption_url'], $request_body->redemption_url);
+  }
+
+  /**
+   * Tests getting promo codes
+   */
+  public function testGetPromoCodes() {
+    $store_id = 'MC001';
+    $promo_rule_id = 'promo0001';
+    $mc = new MailchimpEcommerce();
+    $mc->getPromoCodes($store_id, $promo_rule_id);
+    // Check method.
+    $this->assertEquals('GET', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $promo_rule_id . '/promo-codes', $mc->getClient()->uri);
+  }
+
+  /**
+   * Tests getting a promo code
+   */
+  public function testGetPromoCode() {
+    $store_id = 'MC001';
+    $promo_rule_id = 'promo0001';
+    $promo_code_id = 'code001';
+    $mc = new MailchimpEcommerce();
+    $mc->getPromoCode($store_id, $promo_rule_id, $promo_code_id);
+    // Check method.
+    $this->assertEquals('GET', $mc->getClient()->method);
+    // Check URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $promo_rule_id . '/promo-codes/' . $promo_code_id, $mc->getClient()->uri);
+  }
+
+  /**
+   * Tests deleting a promo code
+   */
+  public function testDeletePromoCode() {
+    $store_id = 'MC001';
+    $promo_rule_id = 'promo0001';
+    $promo_code_id = 'code001';
+    $mc = new MailchimpEcommerce();
+    $mc->deletePromoCode($store_id, $promo_rule_id, $promo_code_id);
+    // Method must be DELETE.
+    $this->assertEquals('DELETE', $mc->getClient()->method);
+    // Confirm URI being used.
+    $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/promo-rules/' . $promo_rule_id . '/promo-codes/' . $promo_code_id, $mc->getClient()->uri);
+  }
+
 }


### PR DESCRIPTION
Added all functions and tests for promo rules and promo codes in the Mailchimp Ecommerce endpoint.