### PR TITLE
Add getMemberTags method

### DIFF
--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -336,6 +336,29 @@ class MailchimpLists extends Mailchimp {
   }
 
   /**
+   * Gets tags related to a member of a MailChimp list.
+   *
+   * @param string $list_id
+   *   The ID of the list.
+   * @param string $email
+   *   The member's email address.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/#read-get_lists_list_id_members_subscriber_hash_tags
+   */
+  public function getMemberTags($list_id, $email, $parameters = []) {
+    $tokens = [
+      'list_id' => $list_id,
+      'subscriber_hash' => md5(strtolower($email)),
+    ];
+
+    return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
+  }
+
+  /**
    * Gets information about segments associated with a Mailchimp list.
    *
    * @param string $list_id

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -199,6 +199,20 @@ class MailchimpListsTest extends TestCase {
   }
 
   /**
+   * Tests library functionality for member tags information.
+   */
+  public function testGetMemberTags() {
+    $list_id = '57afe96172';
+    $email = 'test@example.com';
+
+    $mc = new MailchimpLists();
+    $mc->getMemberTags($list_id, $email);
+
+    $this->assertEquals('GET', $mc->getClient()->method);
+    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members/' . md5($email) . '/tags', $mc->getClient()->uri);
+  }
+
+  /**
    * Tests library functionality for list segment information.
    */
   public function testGetSegments() {


### PR DESCRIPTION
This PR adds the `MailchimpLists:getMemberTags` method, which gets the tags on a list member.
https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/#read-get_lists_list_id_members_subscriber_hash_tags