### PR TITLE
changing http_build_query to drupal_http_build_query to make it work …

### DIFF
--- a/src/http/MailchimpCurlHttpClient.php
+++ b/src/http/MailchimpCurlHttpClient.php
@@ -46,7 +46,7 @@ class MailchimpCurlHttpClient implements MailchimpHttpClientInterface {
         break;
 
       case 'GET':
-        $uri .= '?' . http_build_query($parameters);
+        $uri .= '?' . drupal_http_build_query($parameters);
         break;
 
       case 'PUT':


### PR DESCRIPTION
Fix #88 : Changing http_build_query to drupal_http_build_query here to make it work with php 5.4 when getting templates:

      case 'GET':
        $uri .= '?' . drupal_http_build_query($parameters);
        break;