### PR TITLE
Remove missing error object attribute from MailchimpAPIException

### DIFF
--- a/src/MailchimpAPIException.php
+++ b/src/MailchimpAPIException.php
@@ -18,7 +18,7 @@ class MailchimpAPIException extends Exception {
     // Construct message from JSON if required.
     if (substr($message, 0, 1) == '{') {
       $message_obj = json_decode($message);
-      $message = $message_obj->status . ': ' . $message_obj->title . ' - ' . $message_obj->detail;
+      $message = $message_obj->status . ': ' . $message_obj->title;
       if (!empty($message_obj->errors)) {
         $message .= ' ' . serialize($message_obj->errors);
       }


### PR DESCRIPTION
Fixes https://github.com/thinkshout/mailchimp-api-php/issues/94