### PR TITLE
Issue 3189464 integrate events

### DIFF
--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -184,6 +184,29 @@ class MailchimpLists extends Mailchimp {
   }
 
   /**
+   * Add an event for a MailChimp list member.
+   *
+   * @param string $list_id
+   *   The ID of the list.
+   * @param string $email
+   *   The member's email address.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *
+   * @see https://mailchimp.com/developer/marketing/api/list-member-events/add-event/
+   */
+  public function addMemberEvent($list_id, $email, $parameters = []) {
+    $tokens = [
+      'list_id' => $list_id,
+      'subscriber_hash' => md5(strtolower($email)),
+    ];
+
+    return $this->request('POST', '/lists/{list_id}/members/{subscriber_hash}/events', $tokens, $parameters);
+  }
+
+  /**
    * Gets information about a member of a MailChimp list.
    *
    * @param string $list_id
@@ -230,6 +253,29 @@ class MailchimpLists extends Mailchimp {
     ];
 
     return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}/activity', $tokens, $parameters);
+  }
+
+  /**
+   * Get events for a MailChimp contact.
+   *
+   * @param string $list_id
+   *   The ID of the list.
+   * @param string $email
+   *   The member's email address.
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *
+   * @see https://mailchimp.com/developer/marketing/api/list-member-events/list-member-events/
+   */
+  public function getMemberEvents($list_id, $email, $parameters = []) {
+    $tokens = [
+      'list_id' => $list_id,
+      'subscriber_hash' => md5(strtolower($email)),
+    ];
+
+    return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}/events', $tokens, $parameters);
   }
 
   /**

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -338,6 +338,6 @@ class MailchimpListsTest extends TestCase {
 
     $request_body = $mc->getClient()->options['json'];
 
-    $this->assertEquals($email, $request_body->email_address);
+    $this->assertEquals($event, (array) $request_body);
   }
 }

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -137,6 +137,20 @@ class MailchimpListsTest extends TestCase {
   }
 
   /**
+   * Tests library functionality for member events information.
+   */
+  public function testGetMemberEvents() {
+    $list_id = '57afe96172';
+    $email = 'test@example.com';
+
+    $mc = new MailchimpLists();
+    $mc->getMemberEvents($list_id, $email);
+
+    $this->assertEquals('GET', $mc->getClient()->method);
+    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members/' . md5($email) . '/events', $mc->getClient()->uri);
+  }
+
+  /**
    * Tests library functionality for adding a list member.
    */
   public function testAddMember() {
@@ -301,4 +315,29 @@ class MailchimpListsTest extends TestCase {
     $this->assertEquals($email, $request_body->email_address);
   }
 
+  /**
+   * Tests library functionality for adding a member event.
+   */
+  public function testAddMemberEvent() {
+    $list_id = '205d96e6b4';
+    $email = 'test@example.com';
+    $event = [
+        "name" => "registered_referral",
+        "properties" => [
+          "ref-code-123456"
+        ],
+      ];
+
+    $mc = new MailchimpLists();
+    $mc->AddMemberEvent($list_id, $email, $event);
+
+    $this->assertEquals('POST', $mc->getClient()->method);
+    $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members/' . md5($email) . '/events', $mc->getClient()->uri);
+
+    $this->assertNotEmpty($mc->getClient()->options['json']);
+
+    $request_body = $mc->getClient()->options['json'];
+
+    $this->assertEquals($email, $request_body->email_address);
+  }
 }


### PR DESCRIPTION
Adds the AddMemberEvent and getMemberEvents methods, plus unit tests.

Based on 
https://mailchimp.com/developer/marketing/api/list-member-events/add-event/

and
https://mailchimp.com/developer/marketing/api/list-member-events/list-member-events/

I think this is actually ready for review/merge, based on the prototype & testing instructions in this PR: https://github.com/thinkshout/inkling/pull/5