### PR TITLE
PHP 8 fix: $parameter parameter of request() accepts an array as default not NULL

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -263,7 +263,7 @@ class Mailchimp {
    *
    * @throws MailchimpAPIException
    */
-  public function request($method, $path, $tokens = NULL, $parameters = NULL, $batch = FALSE, $returnAssoc = FALSE) {
+  public function request($method, $path, $tokens = NULL, $parameters = [], $batch = FALSE, $returnAssoc = FALSE) {
     if (!empty($tokens)) {
       foreach ($tokens as $key => $value) {
         $path = str_replace('{' . $key . '}', $value, $path);

--- a/src/MailchimpCampaigns.php
+++ b/src/MailchimpCampaigns.php
@@ -135,7 +135,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('GET', '/campaigns/{campaign_id}/send-checklist', $tokens, NULL);
+    return $this->request('GET', '/campaigns/{campaign_id}/send-checklist', $tokens, []);
   }
 
   /**
@@ -251,7 +251,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('POST', '/campaigns/{campaign_id}/actions/unschedule', $tokens, NULL);
+    return $this->request('POST', '/campaigns/{campaign_id}/actions/unschedule', $tokens, []);
   }
 
   /**

--- a/src/MailchimpCampaigns.php
+++ b/src/MailchimpCampaigns.php
@@ -271,7 +271,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('POST', '/campaigns/{campaign_id}/actions/send', $tokens, NULL, $batch);
+    return $this->request('POST', '/campaigns/{campaign_id}/actions/send', $tokens, [], $batch);
   }
 
   /**


### PR DESCRIPTION
mailchimp-api-php/src/http/MailchimpCurlHttpClient.php calls http_build_query passing NULL which is an error in PHP 8.