### PR TITLE
Updates dependencies for security and PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^6.2.1|^7.0.0"
+    "guzzlehttp/guzzle": "^6.5.6|^7.4.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.2.2"
+    "phpunit/phpunit": "^6.2.2|^7.0|^8.0|^9.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "thinkshout/mailchimp-api-php",
+  "version": "2.0.0",
   "type": "library",
   "description": "PHP library for v3 of the MailChimp API",
   "keywords": ["mailchimp", "mail"],

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^6.5.6|^7.4.3"
+    "guzzlehttp/guzzle": "^6.5.8|^7.4.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.2.2|^7.0|^8.0|^9.0"

--- a/tests/src/MailchimpTestHttpResponse.php
+++ b/tests/src/MailchimpTestHttpResponse.php
@@ -2,6 +2,8 @@
 
 namespace Mailchimp\Tests;
 
+use Psr\Http\Message\StreamInterface;
+
 /**
  * Test HTTP Response.
  *
@@ -9,7 +11,7 @@ namespace Mailchimp\Tests;
  */
 class MailchimpTestHttpResponse extends \GuzzleHttp\Psr7\Response {
 
-  public function getBody() {
+  public function getBody(): StreamInterface {
     return '{}';
   }
 

--- a/tests/src/MailchimpTestHttpResponse.php
+++ b/tests/src/MailchimpTestHttpResponse.php
@@ -2,6 +2,8 @@
 
 namespace Mailchimp\Tests;
 
+use GuzzleHttp\Psr7\Response;
+use Guzzlehttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -9,10 +11,10 @@ use Psr\Http\Message\StreamInterface;
  *
  * @package Mailchimp\Tests
  */
-class MailchimpTestHttpResponse extends \GuzzleHttp\Psr7\Response {
+class MailchimpTestHttpResponse extends Response {
 
   public function getBody(): StreamInterface {
-    return '{}';
+    return Utils::streamFor();
   }
 
 }


### PR DESCRIPTION
I needed to test this library on PHP 8, which requires an update to guzzle 7 and composer reported a conflict between phpunit and guzzle. I saw it fit to add the latest secure releases of Guzzle 6 and 7 also.

PHPunit tests pass, excepting `MailchimpTest::testVersion()` and `MailchimpConnectedSitesTest` which has not tests. I also ran the basic functional test as recommended in the readme.