### PR TITLE
Remove API playground; no longer supported by MailChimp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,3 @@ source ~/.bash_profile
 Then run PHPUnit:
 
 `phpunit`
-
-### Mailchimp API Playground
-
-Mailchimp's [API Playground](https://us1.api.mailchimp.com/playground/) provides
-access to all API methods via a web-based UI. You can use this to test API calls
-and review data you've sent to Mailchimp.


### PR DESCRIPTION
MailChimp has decided to sunset the API playground. Sadly, I could find no replacement.

https://mailchimp.com/developer/release-notes/sunsetting-the-mailchimp-api-playground/