### PR TITLE
Refactors classes to allow api_key and oauth access_tokens

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -47,7 +47,7 @@ class Mailchimp implements MailchimpApiInterface {
    *
    * @var MailchimpHttpClientInterface $client
    */
-  protected $client;
+  public $client;
 
   /**
    * The REST API endpoint.

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -5,13 +5,14 @@ namespace Mailchimp;
 use Mailchimp\http\MailchimpCurlHttpClient;
 use Mailchimp\http\MailchimpGuzzleHttpClient;
 use Mailchimp\http\MailchimpHttpClientInterface;
+use Mailchimp\MailchimpApiInterface;
 
 /**
  * Mailchimp library.
  *
  * @package Mailchimp
  */
-class Mailchimp {
+class Mailchimp implements MailchimpApiInterface {
 
   const VERSION = '2.0.0';
   const DEFAULT_DATA_CENTER = 'us1';
@@ -80,6 +81,13 @@ class Mailchimp {
   private $debug_error_code;
 
   /**
+   * Authentication settings.
+   *
+   * @var array $authentication_settings
+   */
+  protected $authentication_settings;
+
+  /**
    * Array of pending batch operations.
    *
    * @var array $batch_operations
@@ -91,18 +99,16 @@ class Mailchimp {
   /**
    * Mailchimp constructor.
    *
-   * @param string $api_key
-   *   The Mailchimp API key.
-   * @param string $api_user
-   *   The Mailchimp API username.
+   * @param array $authentication_settings
+   *   Authentication settings.
    * @param array $http_options
    *   HTTP client options.
    * @param MailchimpHttpClientInterface $client
    *   Optional custom HTTP client. $http_options are ignored if this is set.
    */
-  public function __construct($api_key, $api_user = 'apikey', $http_options = [], MailchimpHttpClientInterface $client = NULL) {
-    $this->api_key = $api_key;
-    $this->api_user = $api_user;
+  public function __construct($authentication_settings, $http_options = [], MailchimpHttpClientInterface $client = NULL) {
+    $this->api_key = $authentication_settings['api_key'];
+    $this->api_user = $authentication_settings['api_user'];
 
     $dc = $this->getDataCenter($this->api_key);
 
@@ -114,87 +120,6 @@ class Mailchimp {
     else {
       $this->client = $this->getDefaultHttpClient($http_options);
     }
-  }
-
-  /**
-   * Sets a custom HTTP client to be used for all API requests.
-   *
-   * @param \Mailchimp\http\MailchimpHttpClientInterface $client
-   *   The HTTP client.
-   */
-  public function setClient(MailchimpHttpClientInterface $client) {
-    $this->client = $client;
-  }
-
-  /**
-   * Sets a Mailchimp error code to be returned by all requests.
-   *
-   * Used to test and debug error handling.
-   *
-   * @param string $error_code
-   *   The Mailchimp error code.
-   */
-  public function setDebugErrorCode($error_code) {
-    $this->debug_error_code = $error_code;
-  }
-
-  /**
-   * Gets Mailchimp account information for the authenticated account.
-   *
-   * @param array $parameters
-   *   Associative array of optional request parameters.
-   *
-   * @return object
-   *
-   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/root/#read-get_root
-   */
-  public function getAccount($parameters = []) {
-    return $this->request('GET', '/', NULL, $parameters);
-  }
-
-  /**
-   * Processes all pending batch operations.
-   *
-   * @throws MailchimpAPIException
-   *
-   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#create-post_batches
-   */
-  public function processBatchOperations() {
-    $parameters = [
-      'operations' => $this->batch_operations,
-    ];
-
-    try {
-      $response = $this->request('POST', '/batches', NULL, $parameters);
-
-      // Reset batch operations.
-      $this->batch_operations = [];
-
-      return $response;
-
-    }
-    catch (MailchimpAPIException $e) {
-      $message = 'Failed to process batch operations: ' . $e->getMessage();
-      throw new MailchimpAPIException($message, $e->getCode(), $e);
-    }
-  }
-
-  /**
-   * Gets the status of a batch request.
-   *
-   * @param string $batch_id
-   *   The ID of the batch operation.
-   *
-   * @return object
-   *
-   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#read-get_batches_batch_id
-   */
-  public function getBatchOperation($batch_id) {
-    $tokens = [
-      'batch_id' => $batch_id,
-    ];
-
-    return $this->request('GET', '/batches/{batch_id}', $tokens);
   }
 
   /**

--- a/src/Mailchimp2.php
+++ b/src/Mailchimp2.php
@@ -5,13 +5,14 @@ namespace Mailchimp;
 use Mailchimp\http\MailchimpCurlHttpClient;
 use Mailchimp\http\MailchimpGuzzleHttpClient;
 use Mailchimp\http\MailchimpHttpClientInterface;
+use Mailchimp\MailchimpApiInterface;
 
 /**
- * Mailchimp library with access token authentication.
+ * Mailchimp library with OAuth support.
  *
  * @package Mailchimp
  */
-class Mailchimp2 {
+class Mailchimp2 implements MailchimpApiInterface {
 
   const VERSION = '2.0.0';
   const DEFAULT_DATA_CENTER = 'us1';
@@ -46,7 +47,7 @@ class Mailchimp2 {
    *
    * @var MailchimpHttpClientInterface $client
    */
-  protected $client;
+  public $client;
 
   /**
    * The REST API endpoint.
@@ -89,23 +90,26 @@ class Mailchimp2 {
   private $batch_operations;
 
   /**
+   * Authentication settings.
+   *
+   * @var array $authentication_settings
+   */
+  protected $authentication_settings;
+
+  /**
    * Mailchimp constructor.
    *
-   * @param string $access_token
-   *   The Mailchimp Access token.
-   * @param string $data_center
-   *   The Mailchimp data center associated with the account.
-   * @param string $api_user
-   *   The Mailchimp API username.
+   * @param array $authentication_settings
+   *   Authentication settings.
    * @param array $http_options
    *   HTTP client options.
    * @param MailchimpHttpClientInterface $client
    *   Optional custom HTTP client. $http_options are ignored if this is set.
    */
-  public function __construct($access_token, $data_center, $api_user = 'OAuth', $http_options = [], MailchimpHttpClientInterface $client = NULL) {
-    $this->access_token = $access_token;
-    $this->api_user = $api_user;
-    $this->endpoint = str_replace(Mailchimp::DEFAULT_DATA_CENTER, $data_center, $this->endpoint);
+  public function __construct($authentication_settings, $http_options = [], MailchimpHttpClientInterface $client = NULL) {
+    $this->access_token = $authentication_settings['access_token'];
+    $this->api_user = $authentication_settings['api_user'];
+    $this->endpoint = str_replace(Mailchimp::DEFAULT_DATA_CENTER, $authentication_settings['data_center'], $this->endpoint);
 
     if (!empty($client)) {
       $this->client = $client;
@@ -113,87 +117,6 @@ class Mailchimp2 {
     else {
       $this->client = $this->getDefaultHttpClient($http_options);
     }
-  }
-
-  /**
-   * Sets a custom HTTP client to be used for all API requests.
-   *
-   * @param \Mailchimp\http\MailchimpHttpClientInterface $client
-   *   The HTTP client.
-   */
-  public function setClient(MailchimpHttpClientInterface $client) {
-    $this->client = $client;
-  }
-
-  /**
-   * Sets a Mailchimp error code to be returned by all requests.
-   *
-   * Used to test and debug error handling.
-   *
-   * @param string $error_code
-   *   The Mailchimp error code.
-   */
-  public function setDebugErrorCode($error_code) {
-    $this->debug_error_code = $error_code;
-  }
-
-  /**
-   * Gets Mailchimp account information for the authenticated account.
-   *
-   * @param array $parameters
-   *   Associative array of optional request parameters.
-   *
-   * @return object
-   *
-   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/root/#read-get_root
-   */
-  public function getAccount($parameters = []) {
-    return $this->request('GET', '/', NULL, $parameters);
-  }
-
-  /**
-   * Processes all pending batch operations.
-   *
-   * @throws MailchimpAPIException
-   *
-   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#create-post_batches
-   */
-  public function processBatchOperations() {
-    $parameters = [
-      'operations' => $this->batch_operations,
-    ];
-
-    try {
-      $response = $this->request('POST', '/batches', NULL, $parameters);
-
-      // Reset batch operations.
-      $this->batch_operations = [];
-
-      return $response;
-
-    }
-    catch (MailchimpAPIException $e) {
-      $message = 'Failed to process batch operations: ' . $e->getMessage();
-      throw new MailchimpAPIException($message, $e->getCode(), $e);
-    }
-  }
-
-  /**
-   * Gets the status of a batch request.
-   *
-   * @param string $batch_id
-   *   The ID of the batch operation.
-   *
-   * @return object
-   *
-   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#read-get_batches_batch_id
-   */
-  public function getBatchOperation($batch_id) {
-    $tokens = [
-      'batch_id' => $batch_id,
-    ];
-
-    return $this->request('GET', '/batches/{batch_id}', $tokens);
   }
 
   /**
@@ -242,7 +165,7 @@ class Mailchimp2 {
   }
 
   /**
-   * Makes a request to the Mailchimp API.
+   * Makes a request to the Mailchimp API using OAuth.
    *
    * @param string $method
    *   The REST method to use when making the request.

--- a/src/MailchimpApiInterface.php
+++ b/src/MailchimpApiInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Mailchimp;
+
+use Mailchimp\http\MailchimpHttpClientInterface;
+
+/**
+ * Provides an interface a Mailchimp class.
+ *
+ * @internal
+ */
+interface MailchimpApiInterface {
+
+  /**
+   * Makes a request to the Mailchimp API.
+   *
+   * @param string $method
+   *   The REST method to use when making the request.
+   * @param string $path
+   *   The API path to request.
+   * @param array $tokens
+   *   Associative array of tokens and values to replace in the path.
+   * @param array $parameters
+   *   Associative array of parameters to send in the request body.
+   * @param bool $batch
+   *   TRUE if this request should be added to pending batch operations.
+   * @param bool $returnAssoc
+   *   TRUE to return Mailchimp API response as an associative array.
+   *
+   * @return mixed
+   *   Object or Array if $returnAssoc is TRUE.
+   *
+   * @throws MailchimpAPIException
+   */
+  public function request($method, $path, $tokens = NULL, $parameters = [], $batch = FALSE, $returnAssoc = FALSE);
+
+
+}

--- a/src/MailchimpApiInterface.php
+++ b/src/MailchimpApiInterface.php
@@ -5,7 +5,7 @@ namespace Mailchimp;
 use Mailchimp\http\MailchimpHttpClientInterface;
 
 /**
- * Provides an interface a Mailchimp class.
+ * Defines an interface for a Mailchimp API object.
  *
  * @internal
  */

--- a/src/MailchimpApiUser.php
+++ b/src/MailchimpApiUser.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Mailchimp;
+
+use Mailchimp\http\MailchimpHttpClientInterface;
+use Mailchimp\Mailchimp;
+
+/**
+ * Mailchimp API user class.
+ *
+ * @package Mailchimp
+ */
+class MailchimpApiUser {
+
+  /**
+   * The Mailchimp Api Class.
+   *
+   * @var MailchimpApiInterface $apiClass
+   */
+  protected $api_class;
+
+  /**
+   * Mailchimp API user constructor.
+   *
+   * @param MailchimpApiInterface $api_class
+   *   The Mailchimp API Interface object.
+   * @param array $authentication_settings
+   *   Authentication settings.
+   */
+  public function __construct($api_class) {
+    // Call classname and pass values to it.
+    $this->api_class = $api_class;
+  }
+
+    /**
+   * Sets a custom HTTP client to be used for all API requests.
+   *
+   * @param \Mailchimp\http\MailchimpHttpClientInterface $client
+   *   The HTTP client.
+   */
+  public function setClient(MailchimpHttpClientInterface $client) {
+    $this->api_class->client = $client;
+  }
+
+  /**
+   * Sets a Mailchimp error code to be returned by all requests.
+   *
+   * Used to test and debug error handling.
+   *
+   * @param string $error_code
+   *   The Mailchimp error code.
+   */
+  public function setDebugErrorCode($error_code) {
+    $this->api_class->debug_error_code = $error_code;
+  }
+
+  /**
+   * Gets Mailchimp account information for the authenticated account.
+   *
+   * @param array $parameters
+   *   Associative array of optional request parameters.
+   *
+   * @return object
+   *
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/root/#read-get_root
+   */
+  public function getAccount($parameters = []) {
+    return $this->api_class->request('GET', '/', NULL, $parameters);
+  }
+
+  /**
+   * Gets the status of a batch request.
+   *
+   * @param string $batch_id
+   *   The ID of the batch operation.
+   *
+   * @return object
+   *
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#read-get_batches_batch_id
+   */
+  public function getBatchOperation($batch_id) {
+    $tokens = [
+      'batch_id' => $batch_id,
+    ];
+
+    return $this->api_class->request('GET', '/batches/{batch_id}', $tokens);
+  }
+
+    /**
+   * Processes all pending batch operations.
+   *
+   * @throws MailchimpAPIException
+   *
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#create-post_batches
+   */
+  public function processBatchOperations() {
+    $parameters = [
+      'operations' => $this->api_class->batch_operations,
+    ];
+
+    try {
+      $response = $this->api_class->request('POST', '/batches', NULL, $parameters);
+
+      // Reset batch operations.
+      $this->api_class->batch_operations = [];
+
+      return $response;
+
+    }
+    catch (MailchimpAPIException $e) {
+      $message = 'Failed to process batch operations: ' . $e->getMessage();
+      throw new MailchimpAPIException($message, $e->getCode(), $e);
+    }
+  }
+
+
+}

--- a/src/MailchimpAutomations.php
+++ b/src/MailchimpAutomations.php
@@ -2,7 +2,7 @@
 
 namespace Mailchimp;
 
-class MailchimpAutomations extends Mailchimp {
+class MailchimpAutomations extends MailchimpApiUser {
 
   /**
    * Gets information about all automations owned by the authenticated account.
@@ -15,7 +15,7 @@ class MailchimpAutomations extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/automations/#read-get_automations
    */
   public function getAutomations($parameters = []) {
-    return $this->request('GET', '/automations', NULL, $parameters);
+    return $this->api_class->request('GET', '/automations', NULL, $parameters);
   }
 
   /**
@@ -33,7 +33,7 @@ class MailchimpAutomations extends Mailchimp {
       'workflow_id' => $workflow_id,
     ];
 
-    return $this->request('GET', '/automations/{workflow_id}', $tokens);
+    return $this->api_class->request('GET', '/automations/{workflow_id}', $tokens);
   }
 
   /**
@@ -51,7 +51,7 @@ class MailchimpAutomations extends Mailchimp {
       'workflow_id' => $workflow_id,
     ];
 
-    return $this->request('GET', '/automations/{workflow_id}/emails', $tokens);
+    return $this->api_class->request('GET', '/automations/{workflow_id}/emails', $tokens);
   }
 
   /**
@@ -72,7 +72,7 @@ class MailchimpAutomations extends Mailchimp {
       'workflow_email_id' => $workflow_email_id,
     ];
 
-    return $this->request('GET', '/automations/{workflow_id}/emails/{workflow_email_id}', $tokens);
+    return $this->api_class->request('GET', '/automations/{workflow_id}/emails/{workflow_email_id}', $tokens);
   }
 
   /**
@@ -93,7 +93,7 @@ class MailchimpAutomations extends Mailchimp {
       'workflow_email_id' => $workflow_email_id,
     ];
 
-    return $this->request('GET', '/automations/{workflow_id}/emails/{workflow_email_id}/queue', $tokens);
+    return $this->api_class->request('GET', '/automations/{workflow_id}/emails/{workflow_email_id}/queue', $tokens);
   }
 
   /**
@@ -117,7 +117,7 @@ class MailchimpAutomations extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('GET', '/automations/{workflow_id}/emails/{workflow_email_id}/queue/{subscriber_hash}', $tokens);
+    return $this->api_class->request('GET', '/automations/{workflow_id}/emails/{workflow_email_id}/queue/{subscriber_hash}', $tokens);
   }
 
   /**
@@ -146,7 +146,7 @@ class MailchimpAutomations extends Mailchimp {
       'email_address' => $email,
     ];
 
-    return $this->request('POST', '/automations/{workflow_id}/emails/{workflow_email_id}/queue', $tokens, $parameters);
+    return $this->api_class->request('POST', '/automations/{workflow_id}/emails/{workflow_email_id}/queue', $tokens, $parameters);
   }
 
 }

--- a/src/MailchimpCampaigns.php
+++ b/src/MailchimpCampaigns.php
@@ -7,7 +7,7 @@ namespace Mailchimp;
  *
  * @package Mailchimp
  */
-class MailchimpCampaigns extends Mailchimp {
+class MailchimpCampaigns extends MailchimpApiUser {
 
   const EMAIL_TYPE_HTML = 'html';
   const EMAIL_TYPE_PLAIN_TEXT = 'plain_text';
@@ -29,7 +29,7 @@ class MailchimpCampaigns extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#read-get_campaigns
    */
   public function getCampaigns($parameters = []) {
-    return $this->request('GET', '/campaigns', NULL, $parameters);
+    return $this->api_class->request('GET', '/campaigns', NULL, $parameters);
   }
 
   /**
@@ -49,7 +49,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('GET', '/campaigns/{campaign_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/campaigns/{campaign_id}', $tokens, $parameters);
   }
 
   /**
@@ -77,7 +77,7 @@ class MailchimpCampaigns extends Mailchimp {
       'settings' => $settings,
     ];
 
-    return $this->request('POST', '/campaigns', NULL, $parameters, $batch);
+    return $this->api_class->request('POST', '/campaigns', NULL, $parameters, $batch);
   }
 
   /**
@@ -97,7 +97,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('GET', '/campaigns/{campaign_id}/content', $tokens, $parameters);
+    return $this->api_class->request('GET', '/campaigns/{campaign_id}/content', $tokens, $parameters);
   }
 
   /**
@@ -117,7 +117,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('PUT', '/campaigns/{campaign_id}/content', $tokens, $parameters);
+    return $this->api_class->request('PUT', '/campaigns/{campaign_id}/content', $tokens, $parameters);
   }
 
   /**
@@ -135,7 +135,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('GET', '/campaigns/{campaign_id}/send-checklist', $tokens, []);
+    return $this->api_class->request('GET', '/campaigns/{campaign_id}/send-checklist', $tokens, []);
   }
 
   /**
@@ -169,7 +169,7 @@ class MailchimpCampaigns extends Mailchimp {
       'settings' => $settings,
     ];
 
-    return $this->request('PATCH', '/campaigns/{campaign_id}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PATCH', '/campaigns/{campaign_id}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -200,7 +200,7 @@ class MailchimpCampaigns extends Mailchimp {
       'send_type' => $send_type,
     ];
 
-    return $this->request('POST', '/campaigns/{campaign_id}/actions/test', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/campaigns/{campaign_id}/actions/test', $tokens, $parameters, $batch);
   }
 
   /**
@@ -233,7 +233,7 @@ class MailchimpCampaigns extends Mailchimp {
       'batch_delivery' => $batch_delivery,
     ];
 
-    return $this->request('POST', '/campaigns/{campaign_id}/actions/schedule', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/campaigns/{campaign_id}/actions/schedule', $tokens, $parameters, $batch);
   }
 
   /**
@@ -251,7 +251,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('POST', '/campaigns/{campaign_id}/actions/unschedule', $tokens, []);
+    return $this->api_class->request('POST', '/campaigns/{campaign_id}/actions/unschedule', $tokens, []);
   }
 
   /**
@@ -271,7 +271,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('POST', '/campaigns/{campaign_id}/actions/send', $tokens, [], $batch);
+    return $this->api_class->request('POST', '/campaigns/{campaign_id}/actions/send', $tokens, [], $batch);
   }
 
   /**
@@ -289,7 +289,7 @@ class MailchimpCampaigns extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('DELETE', '/campaigns/{campaign_id}', $tokens);
+    return $this->api_class->request('DELETE', '/campaigns/{campaign_id}', $tokens);
   }
 
 }

--- a/src/MailchimpConnectedSites.php
+++ b/src/MailchimpConnectedSites.php
@@ -9,7 +9,7 @@ namespace Mailchimp;
  *
  * @see https://kb.mailchimp.com/integrations/connected-sites/about-connected-sites
  */
-class MailchimpConnectedSites extends Mailchimp {
+class MailchimpConnectedSites extends MailchimpApiUser {
 
   /**
    * Gets information about all connected sites for the authenticated account.
@@ -20,7 +20,7 @@ class MailchimpConnectedSites extends Mailchimp {
    * @return object
    */
   public function getConnectedSites($parameters = []) {
-    return $this->request('GET', '/connected-sites', NULL, $parameters);
+    return $this->api_class->request('GET', '/connected-sites', NULL, $parameters);
   }
 
   /**
@@ -38,7 +38,7 @@ class MailchimpConnectedSites extends Mailchimp {
       'connected_site_id' => $connected_site_id,
     ];
 
-    return $this->request('GET', '/connected-sites/{connected_site_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/connected-sites/{connected_site_id}', $tokens, $parameters);
   }
 
 }

--- a/src/MailchimpEcommerce.php
+++ b/src/MailchimpEcommerce.php
@@ -7,7 +7,7 @@ namespace Mailchimp;
  *
  * @package Mailchimp
  */
-class MailchimpEcommerce extends Mailchimp {
+class MailchimpEcommerce extends MailchimpApiUser {
 
   /**
    * Gets information about all stores in the account.
@@ -21,7 +21,7 @@ class MailchimpEcommerce extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/ecommerce/stores/#read-get_ecommerce_stores
    */
   public function getStores($parameters = []) {
-    return $this->request('GET', '/ecommerce/stores', NULL, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores', NULL, $parameters);
   }
 
   /**
@@ -42,7 +42,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}', $tokens, $parameters);
   }
 
   /**
@@ -70,7 +70,7 @@ class MailchimpEcommerce extends Mailchimp {
     $parameters['id'] = $id;
     $parameters += $store;
 
-    return $this->request('POST', '/ecommerce/stores', NULL, $parameters, $batch);
+    return $this->api_class->request('POST', '/ecommerce/stores', NULL, $parameters, $batch);
   }
 
   /**
@@ -102,7 +102,7 @@ class MailchimpEcommerce extends Mailchimp {
       'currency_code' => $currency_code,
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -121,7 +121,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}', $tokens);
   }
 
   /**
@@ -142,7 +142,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/carts', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/carts', $tokens, $parameters);
   }
 
   /**
@@ -166,7 +166,7 @@ class MailchimpEcommerce extends Mailchimp {
       'cart_id' => $cart_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/carts/{cart_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/carts/{cart_id}', $tokens, $parameters);
   }
 
   /**
@@ -204,7 +204,7 @@ class MailchimpEcommerce extends Mailchimp {
 
     $parameters += $cart;
 
-    return $this->request('POST', '/ecommerce/stores/{store_id}/carts', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/carts', $tokens, $parameters, $batch);
   }
 
   /**
@@ -230,7 +230,7 @@ class MailchimpEcommerce extends Mailchimp {
       'cart_id' => $cart_id,
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/carts/{cart_id}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/carts/{cart_id}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -252,7 +252,7 @@ class MailchimpEcommerce extends Mailchimp {
       'cart_id' => $cart_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/carts/{cart_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/carts/{cart_id}', $tokens);
   }
 
   /**
@@ -276,7 +276,7 @@ class MailchimpEcommerce extends Mailchimp {
       'cart_id' => $cart_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines', $tokens, $parameters);
   }
 
   /**
@@ -303,7 +303,7 @@ class MailchimpEcommerce extends Mailchimp {
       'line_id' => $line_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines/{line_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines/{line_id}', $tokens, $parameters);
   }
 
   /**
@@ -341,7 +341,7 @@ class MailchimpEcommerce extends Mailchimp {
 
     $parameters += $product;
 
-    return $this->request('POST', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines', $tokens, $parameters, $batch);
   }
 
   /**
@@ -370,7 +370,7 @@ class MailchimpEcommerce extends Mailchimp {
       'line_id' => $line_id,
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines/{line_id}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines/{line_id}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -395,7 +395,7 @@ class MailchimpEcommerce extends Mailchimp {
       'line_id' => $line_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines/{line_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/carts/{cart_id}/lines/{line_id}', $tokens);
   }
 
   /**
@@ -416,7 +416,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/customers', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/customers', $tokens, $parameters);
   }
 
   /**
@@ -440,7 +440,7 @@ class MailchimpEcommerce extends Mailchimp {
       'customer_id' => $customer_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/' . $store_id . '/customers/' . $customer_id, $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/' . $store_id . '/customers/' . $customer_id, $tokens, $parameters);
   }
 
   /**
@@ -469,7 +469,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('POST', '/ecommerce/stores/{store_id}/customers', $tokens, $customer, $batch);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/customers', $tokens, $customer, $batch);
   }
 
   /**
@@ -498,7 +498,7 @@ class MailchimpEcommerce extends Mailchimp {
       'customer_id' => $customer['id'],
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/customers/{customer_id}', $tokens, $customer, $batch);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/customers/{customer_id}', $tokens, $customer, $batch);
   }
 
   /**
@@ -520,7 +520,7 @@ class MailchimpEcommerce extends Mailchimp {
       'customer_id' => $customer_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/customers/{customer_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/customers/{customer_id}', $tokens);
   }
 
   /**
@@ -541,7 +541,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/orders', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/orders', $tokens, $parameters);
   }
 
   /**
@@ -565,7 +565,7 @@ class MailchimpEcommerce extends Mailchimp {
       'order_id' => $order_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/' . $store_id . '/orders/' . $order_id, $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/' . $store_id . '/orders/' . $order_id, $tokens, $parameters);
   }
 
   /**
@@ -603,7 +603,7 @@ class MailchimpEcommerce extends Mailchimp {
 
     $parameters += $order;
 
-    return $this->request('POST', '/ecommerce/stores/{store_id}/orders', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/orders', $tokens, $parameters, $batch);
   }
 
   /**
@@ -631,7 +631,7 @@ class MailchimpEcommerce extends Mailchimp {
       'order_id' => $order_id,
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/orders/{order_id}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/orders/{order_id}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -653,7 +653,7 @@ class MailchimpEcommerce extends Mailchimp {
       'order_id' => $order_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/orders/{order_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/orders/{order_id}', $tokens);
   }
 
   /**
@@ -679,7 +679,7 @@ class MailchimpEcommerce extends Mailchimp {
       'order_id' => $order_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/orders/{order_id}/lines', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/orders/{order_id}/lines', $tokens, $parameters);
   }
 
   /**
@@ -708,7 +708,7 @@ class MailchimpEcommerce extends Mailchimp {
       'line_id' => $line_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/orders/{order_id}/lines/{line_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/orders/{order_id}/lines/{line_id}', $tokens, $parameters);
   }
 
   /**
@@ -746,7 +746,7 @@ class MailchimpEcommerce extends Mailchimp {
 
     $parameters += $product;
 
-    return $this->request('POST', '/ecommerce/stores/{store_id}/orders/{order_id}/lines', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/orders/{order_id}/lines', $tokens, $parameters, $batch);
   }
 
   /**
@@ -769,7 +769,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/products', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/products', $tokens, $parameters);
   }
 
   /**
@@ -795,7 +795,7 @@ class MailchimpEcommerce extends Mailchimp {
       'product_id' => $product_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/products/{product_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/products/{product_id}', $tokens, $parameters);
   }
 
   /**
@@ -833,7 +833,7 @@ class MailchimpEcommerce extends Mailchimp {
       'variants' => $variants,
     ];
 
-    return $this->request('POST', '/ecommerce/stores/{store_id}/products', $tokens, $parameters);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/products', $tokens, $parameters);
   }
 
   /**
@@ -867,7 +867,7 @@ class MailchimpEcommerce extends Mailchimp {
       'variants' => $variants,
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/products/{product_id}', $tokens, $parameters);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/products/{product_id}', $tokens, $parameters);
   }
 
   /**
@@ -891,7 +891,7 @@ class MailchimpEcommerce extends Mailchimp {
       'product_id' => $product_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/products/{product_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/products/{product_id}', $tokens);
   }
 
   /**
@@ -917,7 +917,7 @@ class MailchimpEcommerce extends Mailchimp {
       'product_id' => $product_id,
     ];
 
-    return $this->request('POST', '/ecommerce/stores/{store_id}/products/{product_id}/variants', $tokens, $parameters);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/products/{product_id}/variants', $tokens, $parameters);
   }
 
   /**
@@ -945,7 +945,7 @@ class MailchimpEcommerce extends Mailchimp {
       'product_id' => $product_id,
       'variant_id' => $variant_id,
     ];
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/products/{product_id}/variants/{variant_id}', $tokens, $parameters);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/products/{product_id}/variants/{variant_id}', $tokens, $parameters);
   }
 
   /**
@@ -973,7 +973,7 @@ class MailchimpEcommerce extends Mailchimp {
       'product_id' => $product_id,
       'variant_id' => $variant_id,
     ];
-    return $this->request('GET', '/ecommerce/stores/{store_id}/products/{product_id}/variants/{variant_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/products/{product_id}/variants/{variant_id}', $tokens, $parameters);
   }
 
   /**
@@ -996,7 +996,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
       'product_id' => $product_id,
     ];
-    return $this->request('GET', '/ecommerce/stores/{store_id}/products/{product_id}/variants', $tokens);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/products/{product_id}/variants', $tokens);
   }
 
   /**
@@ -1022,7 +1022,7 @@ class MailchimpEcommerce extends Mailchimp {
       'product_id' => $product_id,
       'variant_id' => $variant_id,
     ];
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/products/{product_id}/variants/{variant_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/products/{product_id}/variants/{variant_id}', $tokens);
   }
 
   /**
@@ -1045,7 +1045,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/promo-rules', $tokens, $parameters);
   }
 
   /**
@@ -1070,7 +1070,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
       'promo_rule_id' => $promo_rule_id,
     ];
-    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens, $parameters);
   }
 
   /**
@@ -1102,7 +1102,7 @@ class MailchimpEcommerce extends Mailchimp {
     $tokens = [
       'store_id' => $store_id,
     ];
-    return $this->request('POST', '/ecommerce/stores/{store_id}/promo-rules', $tokens, $promo_rule);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/promo-rules', $tokens, $promo_rule);
   }
 
   /**
@@ -1138,7 +1138,7 @@ class MailchimpEcommerce extends Mailchimp {
       'promo_rule_id' => $promo_rule['id'],
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens, $promo_rule, $batch);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens, $promo_rule, $batch);
   }
 
   /**
@@ -1161,7 +1161,7 @@ class MailchimpEcommerce extends Mailchimp {
       'promo_rule_id' => $promo_rule_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}', $tokens);
   }
 
   /**
@@ -1185,7 +1185,7 @@ class MailchimpEcommerce extends Mailchimp {
       'promo_rule_id' => $promo_rule_id,
     ];
 
-    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes', $tokens, $parameters);
   }
 
   /**
@@ -1211,7 +1211,7 @@ class MailchimpEcommerce extends Mailchimp {
       'promo_rule_id' => $promo_rule_id,
       'promo_code_id' => $promo_code_id,
     ];
-    return $this->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens, $parameters);
   }
 
   /**
@@ -1240,7 +1240,7 @@ class MailchimpEcommerce extends Mailchimp {
       'store_id' => $store_id,
       'promo_rule_id' => $promo_rule_id,
     ];
-    return $this->request('POST', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes', $tokens, $promo_code);
+    return $this->api_class->request('POST', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes', $tokens, $promo_code);
   }
 
   /**
@@ -1273,7 +1273,7 @@ class MailchimpEcommerce extends Mailchimp {
       'promo_code_id' => $promo_code['id'],
     ];
 
-    return $this->request('PATCH', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens, $promo_code, $batch);
+    return $this->api_class->request('PATCH', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens, $promo_code, $batch);
   }
 
   /**
@@ -1300,6 +1300,6 @@ class MailchimpEcommerce extends Mailchimp {
       'promo_code_id' => $promo_code_id,
     ];
 
-    return $this->request('DELETE', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens);
+    return $this->api_class->request('DELETE', '/ecommerce/stores/{store_id}/promo-rules/{promo_rule_id}/promo-codes/{promo_code_id}', $tokens);
   }
 }

--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -7,7 +7,7 @@ namespace Mailchimp;
  *
  * @package Mailchimp
  */
-class MailchimpLists extends Mailchimp {
+class MailchimpLists extends MailchimpApiUser {
 
   const MEMBER_STATUS_SUBSCRIBED = 'subscribed';
   const MEMBER_STATUS_UNSUBSCRIBED = 'unsubscribed';
@@ -25,7 +25,7 @@ class MailchimpLists extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/#read-get_lists
    */
   public function getLists($parameters = []) {
-    return $this->request('GET', '/lists', NULL, $parameters);
+    return $this->api_class->request('GET', '/lists', NULL, $parameters);
   }
 
   /**
@@ -45,7 +45,7 @@ class MailchimpLists extends Mailchimp {
       'list_id' => $list_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}', $tokens, $parameters);
   }
 
   /**
@@ -65,7 +65,7 @@ class MailchimpLists extends Mailchimp {
       'list_id' => $list_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/interest-categories', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/interest-categories', $tokens, $parameters);
   }
 
   /**
@@ -94,7 +94,7 @@ class MailchimpLists extends Mailchimp {
       'type' => $type,
     ];
 
-    return $this->request('POST', '/lists/{list_id}/interest-categories', $tokens, $parameters);
+    return $this->api_class->request('POST', '/lists/{list_id}/interest-categories', $tokens, $parameters);
   }
 
   /**
@@ -126,7 +126,7 @@ class MailchimpLists extends Mailchimp {
       'type' => $type,
     ];
 
-    return $this->request('PATCH', '/lists/{list_id}/interest-categories/{interest_category_id}', $tokens, $parameters);
+    return $this->api_class->request('PATCH', '/lists/{list_id}/interest-categories/{interest_category_id}', $tokens, $parameters);
   }
 
   /**
@@ -149,7 +149,7 @@ class MailchimpLists extends Mailchimp {
       'interest_category_id' => $interest_category_id,
     ];
 
-    return $this->request('DELETE', '/lists/{list_id}/interest-categories/{interest_category_id}', $tokens, $parameters);
+    return $this->api_class->request('DELETE', '/lists/{list_id}/interest-categories/{interest_category_id}', $tokens, $parameters);
   }
 
   /**
@@ -172,7 +172,7 @@ class MailchimpLists extends Mailchimp {
       'interest_category_id' => $interest_category_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/interest-categories/{interest_category_id}/interests', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/interest-categories/{interest_category_id}/interests', $tokens, $parameters);
   }
 
   /**
@@ -201,7 +201,7 @@ class MailchimpLists extends Mailchimp {
       'name' => $name,
     ];
 
-    return $this->request('POST', '/lists/{list_id}/interest-categories/{interest_category_id}/interests', $tokens, $parameters);
+    return $this->api_class->request('POST', '/lists/{list_id}/interest-categories/{interest_category_id}/interests', $tokens, $parameters);
   }
 
   /**
@@ -233,7 +233,7 @@ class MailchimpLists extends Mailchimp {
       'name' => $name,
     ];
 
-    return $this->request('PATCH', '/lists/{list_id}/interest-categories/{interest_category_id}/interests/{interest_id}', $tokens, $parameters);
+    return $this->api_class->request('PATCH', '/lists/{list_id}/interest-categories/{interest_category_id}/interests/{interest_id}', $tokens, $parameters);
   }
 
   /**
@@ -259,7 +259,7 @@ class MailchimpLists extends Mailchimp {
       'interest_id' => $interest_id,
     ];
 
-    return $this->request('DELETE', '/lists/{list_id}/interest-categories/{interest_category_id}/interests/{interest_id}', $tokens, $parameters);
+    return $this->api_class->request('DELETE', '/lists/{list_id}/interest-categories/{interest_category_id}/interests/{interest_id}', $tokens, $parameters);
   }
 
   /**
@@ -279,7 +279,7 @@ class MailchimpLists extends Mailchimp {
       'list_id' => $list_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/merge-fields', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/merge-fields', $tokens, $parameters);
   }
 
   /**
@@ -308,7 +308,7 @@ class MailchimpLists extends Mailchimp {
       'type' => $type,
     ];
 
-    return $this->request('POST', '/lists/{list_id}/merge-fields', $tokens, $parameters);
+    return $this->api_class->request('POST', '/lists/{list_id}/merge-fields', $tokens, $parameters);
   }
 
   /**
@@ -328,7 +328,7 @@ class MailchimpLists extends Mailchimp {
       'list_id' => $list_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/members', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/members', $tokens, $parameters);
   }
 
   /**
@@ -351,7 +351,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters);
   }
 
   /**
@@ -374,7 +374,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('POST', '/lists/{list_id}/members/{subscriber_hash}/events', $tokens, $parameters);
+    return $this->api_class->request('POST', '/lists/{list_id}/members/{subscriber_hash}/events', $tokens, $parameters);
   }
 
   /**
@@ -400,7 +400,7 @@ class MailchimpLists extends Mailchimp {
         'unique_email_id' => $mc_eid,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/members/', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/members/', $tokens, $parameters);
   }
 
   /**
@@ -423,7 +423,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}/activity', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/members/{subscriber_hash}/activity', $tokens, $parameters);
   }
 
   /**
@@ -446,7 +446,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}/events', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/members/{subscriber_hash}/events', $tokens, $parameters);
   }
 
   /**
@@ -474,7 +474,7 @@ class MailchimpLists extends Mailchimp {
       'email_address' => $email,
     ];
 
-    return $this->request('POST', '/lists/{list_id}/members', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/lists/{list_id}/members', $tokens, $parameters, $batch);
   }
 
   /**
@@ -495,7 +495,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('DELETE', '/lists/{list_id}/members/{subscriber_hash}', $tokens);
+    return $this->api_class->request('DELETE', '/lists/{list_id}/members/{subscriber_hash}', $tokens);
   }
 
   /**
@@ -520,7 +520,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('PATCH', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PATCH', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -549,7 +549,7 @@ class MailchimpLists extends Mailchimp {
       'email_address' => $email,
     ];
 
-    return $this->request('PUT', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PUT', '/lists/{list_id}/members/{subscriber_hash}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -572,7 +572,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('GET', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
   }
 
   /**
@@ -592,7 +592,7 @@ class MailchimpLists extends Mailchimp {
       'list_id' => $list_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/segments', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/segments', $tokens, $parameters);
   }
 
   /**
@@ -615,7 +615,7 @@ class MailchimpLists extends Mailchimp {
       'segment_id' => $segment_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/segments/{segment_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/segments/{segment_id}', $tokens, $parameters);
   }
 
   /**
@@ -643,7 +643,7 @@ class MailchimpLists extends Mailchimp {
       'name' => $name,
     ];
 
-    return $this->request('POST', '/lists/{list_id}/segments', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/lists/{list_id}/segments', $tokens, $parameters, $batch);
   }
 
   /**
@@ -674,7 +674,7 @@ class MailchimpLists extends Mailchimp {
       'name' => $name,
     ];
 
-    return $this->request('PATCH', '/lists/{list_id}/segments/{segment_id}', $tokens, $parameters, $batch);
+    return $this->api_class->request('PATCH', '/lists/{list_id}/segments/{segment_id}', $tokens, $parameters, $batch);
   }
 
   /**
@@ -697,7 +697,7 @@ class MailchimpLists extends Mailchimp {
       'segment_id' => $segment_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/segments/{segment_id}/members', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/segments/{segment_id}/members', $tokens, $parameters);
   }
 
   /**
@@ -726,7 +726,7 @@ class MailchimpLists extends Mailchimp {
       'email_address' => $email,
     ];
 
-    return $this->request('POST', '/lists/{list_id}/segments/{segment_id}/members', $tokens, $parameters);
+    return $this->api_class->request('POST', '/lists/{list_id}/segments/{segment_id}/members', $tokens, $parameters);
   }
 
   /**
@@ -750,7 +750,7 @@ class MailchimpLists extends Mailchimp {
       'subscriber_hash' => md5(strtolower($email)),
     ];
 
-    return $this->request('DELETE', '/lists/{list_id}/segments/{segment_id}/members/{subscriber_hash}', $tokens);
+    return $this->api_class->request('DELETE', '/lists/{list_id}/segments/{segment_id}/members/{subscriber_hash}', $tokens);
   }
 
   /**
@@ -782,7 +782,7 @@ class MailchimpLists extends Mailchimp {
       ];
     }
 
-    return $this->request('POST', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
+    return $this->api_class->request('POST', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
   }
 
   /**
@@ -814,7 +814,7 @@ class MailchimpLists extends Mailchimp {
       ];
     }
 
-    return $this->request('POST', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
+    return $this->api_class->request('POST', '/lists/{list_id}/members/{subscriber_hash}/tags', $tokens, $parameters);
   }
 
   /**
@@ -834,7 +834,7 @@ class MailchimpLists extends Mailchimp {
       'list_id' => $list_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/webhooks', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/webhooks', $tokens, $parameters);
   }
 
   /**
@@ -857,7 +857,7 @@ class MailchimpLists extends Mailchimp {
       'webhook_id' => $webhook_id,
     ];
 
-    return $this->request('GET', '/lists/{list_id}/webhooks/{webhook_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/lists/{list_id}/webhooks/{webhook_id}', $tokens, $parameters);
   }
 
   /**
@@ -883,7 +883,7 @@ class MailchimpLists extends Mailchimp {
       'url' => $url,
     ];
 
-    return $this->request('POST', '/lists/{list_id}/webhooks', $tokens, $parameters, $batch);
+    return $this->api_class->request('POST', '/lists/{list_id}/webhooks', $tokens, $parameters, $batch);
   }
 
   /**
@@ -904,7 +904,7 @@ class MailchimpLists extends Mailchimp {
       'webhook_id' => $webhook_id,
     ];
 
-    return $this->request('DELETE', '/lists/{list_id}/webhooks/{webhook_id}', $tokens, $parameters);
+    return $this->api_class->request('DELETE', '/lists/{list_id}/webhooks/{webhook_id}', $tokens, $parameters);
   }
 
   /**

--- a/src/MailchimpReports.php
+++ b/src/MailchimpReports.php
@@ -7,7 +7,7 @@ namespace Mailchimp;
  *
  * @package Mailchimp
  */
-class MailchimpReports extends Mailchimp {
+class MailchimpReports extends MailchimpApiUser {
 
   /**
    * Gets a report summary for the authenticated account.
@@ -20,7 +20,7 @@ class MailchimpReports extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/reports/#read-get_reports
    */
   public function getSummary($parameters = []) {
-    return $this->request('GET', '/reports', NULL, $parameters);
+    return $this->api_class->request('GET', '/reports', NULL, $parameters);
   }
 
   /**
@@ -40,7 +40,7 @@ class MailchimpReports extends Mailchimp {
       'campaign_id' => $campaign_id,
     ];
 
-    return $this->request('GET', '/reports/{campaign_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/reports/{campaign_id}', $tokens, $parameters);
   }
 
   /**
@@ -71,7 +71,7 @@ class MailchimpReports extends Mailchimp {
       'type' => $type,
     ];
 
-    return $this->request('GET', '/reports/{campaign_id}/{type}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/reports/{campaign_id}/{type}', $tokens, $parameters);
   }
 
 }

--- a/src/MailchimpTemplates.php
+++ b/src/MailchimpTemplates.php
@@ -7,7 +7,7 @@ namespace Mailchimp;
  *
  * @package Mailchimp
  */
-class MailchimpTemplates extends Mailchimp {
+class MailchimpTemplates extends MailchimpApiUser {
 
   /**
    * Gets information about all templates owned by the authenticated account.
@@ -20,7 +20,7 @@ class MailchimpTemplates extends Mailchimp {
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/templates/#read-get_templates
    */
   public function getTemplates($parameters = []) {
-    return $this->request('GET', '/templates', NULL, $parameters);
+    return $this->api_class->request('GET', '/templates', NULL, $parameters);
   }
 
   /**
@@ -40,7 +40,7 @@ class MailchimpTemplates extends Mailchimp {
       'template_id' => $template_id,
     ];
 
-    return $this->request('GET', '/templates/{template_id}', $tokens, $parameters);
+    return $this->api_class->request('GET', '/templates/{template_id}', $tokens, $parameters);
   }
 
   /**
@@ -60,7 +60,7 @@ class MailchimpTemplates extends Mailchimp {
       'template_id' => $template_id,
     ];
 
-    return $this->request('GET', '/templates/{template_id}/default-content', $tokens, $parameters);
+    return $this->api_class->request('GET', '/templates/{template_id}/default-content', $tokens, $parameters);
   }
 
 }

--- a/src/MailchimpUser.php
+++ b/src/MailchimpUser.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Mailchimp;
+
+class MailchimpUser extends MailchimpApiUser {}

--- a/src/MailchimpUser.php
+++ b/src/MailchimpUser.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Mailchimp;
-
-class MailchimpUser extends MailchimpApiUser {}


### PR DESCRIPTION
This is a significant refactor to get this library to support access by both api_key and OAuth access_tokens.

It required creating a second Mailchimp class for initializing the connection to Mailchimp's API. Mailchimp class is used for all api_key calls. And Mailchimp2 is used for all OAuth access_token calls. 

Additionally, the structure/relationship with the Classes that were extending the Mailchimp Class had to be reworked. Those classes now are instantiated with a variable for the Mailchimp class depending on which authentication method you need. 

TODO: Update README with new documentation.