### PR TITLE
Allows requests from API user objects

### DIFF
--- a/src/MailchimpApiUser.php
+++ b/src/MailchimpApiUser.php
@@ -17,7 +17,7 @@ class MailchimpApiUser {
    *
    * @var MailchimpApiInterface $apiClass
    */
-  public $api_class;
+  protected $api_class;
 
   /**
    * Mailchimp API user constructor.
@@ -128,6 +128,32 @@ class MailchimpApiUser {
         return isset($this->api_class->access_token);
         break;
     }
+  }
+
+  /**
+   * Passes on request to Mailchimp Api Interface.
+   * This allows backwards compatibilty with existing calls.
+   *
+   * @param string $method
+   *   The REST method to use when making the request.
+   * @param string $path
+   *   The API path to request.
+   * @param array $tokens
+   *   Associative array of tokens and values to replace in the path.
+   * @param array $parameters
+   *   Associative array of parameters to send in the request body.
+   * @param bool $batch
+   *   TRUE if this request should be added to pending batch operations.
+   * @param bool $returnAssoc
+   *   TRUE to return Mailchimp API response as an associative array.
+   *
+   * @return mixed
+   *   Object or Array if $returnAssoc is TRUE.
+   *
+   * @throws MailchimpAPIException
+   */
+  public function request($method, $path, $tokens = NULL, $parameters = [], $batch = FALSE, $returnAssoc = FALSE) {
+    return $this->api_class->request($method, $path, $tokens = NULL, $parameters = [], $batch = FALSE, $returnAssoc = FALSE);
   }
 
 }

--- a/src/MailchimpApiUser.php
+++ b/src/MailchimpApiUser.php
@@ -17,7 +17,7 @@ class MailchimpApiUser {
    *
    * @var MailchimpApiInterface $apiClass
    */
-  protected $api_class;
+  public $api_class;
 
   /**
    * Mailchimp API user constructor.


### PR DESCRIPTION
Fix for #112 

As noted in that issue as of the v3 release of this library non-supported API calls such as this would no longer be possible: 

```
$mailchimp_api = mailchimp_get_api_object('MailchimpLists');
$mailchimp_api->request('DELETE', '/lists/{list_id}/interest-categories/{interest_category_id}/interests/{interest_id}', $tokens);
```

The change in this PR would fix the BC break introduced in the v3 release.