### PR TITLE
Fix version test

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -14,7 +14,7 @@ use Mailchimp\MailchimpApiInterface;
  */
 class Mailchimp implements MailchimpApiInterface {
 
-  const VERSION = '2.0.0';
+  const VERSION = '3.0.0-rc6';
   const DEFAULT_DATA_CENTER = 'us1';
 
   const ERROR_CODE_BAD_REQUEST = 'BadRequest';

--- a/src/Mailchimp2.php
+++ b/src/Mailchimp2.php
@@ -14,7 +14,7 @@ use Mailchimp\MailchimpApiInterface;
  */
 class Mailchimp2 implements MailchimpApiInterface {
 
-  const VERSION = '2.0.0';
+  const VERSION = '3.0.0-rc6';
   const DEFAULT_DATA_CENTER = 'us1';
 
   const ERROR_CODE_BAD_REQUEST = 'BadRequest';

--- a/tests/MailchimpTest.php
+++ b/tests/MailchimpTest.php
@@ -27,7 +27,6 @@ class MailchimpTest extends TestCase {
    */
   public function testVersion() {
     $mc = new Mailchimp();
-    $this->assertEquals($mc::VERSION, '2.0.0');
     $this->assertEquals(json_decode(file_get_contents('composer.json'))->version, $mc::VERSION);
   }
 


### PR DESCRIPTION
The phpunit test for the library version is failing because the constant in the Mailchimp and Mailchimp2 classes is outdated.

This PR:

* Removes a hard-coded version check from MailchimpTest::testVersion() (only need to check against the composer version)
* Updates the VERSION constant in Mailchimp and Mailchimp2 classes

Alternatively, it looks like the VERSION constant could just be removed because it isn't used outside of the phpunit test.