### PR TITLE
Fix tests after version 3 restructuring

### DIFF
--- a/tests/MailchimpAutomationsTest.php
+++ b/tests/MailchimpAutomationsTest.php
@@ -10,7 +10,8 @@ class MailchimpAutomationsTest extends TestCase {
    * Tests library functionality for automations.
    */
   public function testGetAutomations() {
-    $mc = new MailchimpAutomations();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpAutomations($api_user);
     $mc->getAutomations();
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -23,7 +24,8 @@ class MailchimpAutomationsTest extends TestCase {
   public function testGetWorkflow() {
     $workflow_id = '57afe96172';
 
-    $mc = new MailchimpAutomations();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpAutomations($api_user);
     $mc->getWorkflow($workflow_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -36,7 +38,8 @@ class MailchimpAutomationsTest extends TestCase {
   public function testGetWorkflowEmails() {
     $workflow_id = '57afe96172';
 
-    $mc = new MailchimpAutomations();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpAutomations($api_user);
     $mc->getWorkflowEmails($workflow_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -50,7 +53,8 @@ class MailchimpAutomationsTest extends TestCase {
     $workflow_id = '57afe96172';
     $workflow_email_id = 'a87de7d1e5';
 
-    $mc = new MailchimpAutomations();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpAutomations($api_user);
     $mc->getWorkflowEmail($workflow_id, $workflow_email_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -64,7 +68,8 @@ class MailchimpAutomationsTest extends TestCase {
     $workflow_id = '57afe96172';
     $workflow_email_id = 'a87de7d1e5';
 
-    $mc = new MailchimpAutomations();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpAutomations($api_user);
     $mc->getWorkflowEmailSubscribers($workflow_id, $workflow_email_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -79,7 +84,8 @@ class MailchimpAutomationsTest extends TestCase {
     $workflow_email_id = 'a87de7d1e5';
     $email = 'test@example.com';
 
-    $mc = new MailchimpAutomations();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpAutomations($api_user);
     $mc->getWorkflowEmailSubscriber($workflow_id, $workflow_email_id, $email);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -94,7 +100,8 @@ class MailchimpAutomationsTest extends TestCase {
     $workflow_email_id = 'a87de7d1e5';
     $email = 'test@example.com';
 
-    $mc = new MailchimpAutomations();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpAutomations($api_user);
     $mc->addWorkflowEmailSubscriber($workflow_id, $workflow_email_id, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);

--- a/tests/MailchimpCampaignsTest.php
+++ b/tests/MailchimpCampaignsTest.php
@@ -15,7 +15,8 @@ class MailchimpCampaignsTest extends TestCase {
    * Tests library functionality for campaigns information.
    */
   public function testGetCampaigns() {
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->getCampaigns();
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -28,7 +29,8 @@ class MailchimpCampaignsTest extends TestCase {
   public function testGetCampaign() {
     $campaign_id = '42694e9e57';
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->getCampaign($campaign_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -48,7 +50,8 @@ class MailchimpCampaignsTest extends TestCase {
       'from_name' => 'Customer Service',
     ];
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->addCampaign($type, $recipients, $settings);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -71,7 +74,8 @@ class MailchimpCampaignsTest extends TestCase {
   public function testGetCampaignContent() {
     $campaign_id = '42694e9e57';
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->getCampaignContent($campaign_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -87,7 +91,8 @@ class MailchimpCampaignsTest extends TestCase {
       'html' => '<p>The HTML to use for the saved campaign.</p>',
     ];
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->setCampaignContent($campaign_id, $parameters);
 
     $this->assertEquals('PUT', $mc->getClient()->method);
@@ -106,7 +111,8 @@ class MailchimpCampaignsTest extends TestCase {
   public function testGetSendChecklist() {
     $campaign_id = '42694e9e57';
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->getSendChecklist($campaign_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -127,7 +133,8 @@ class MailchimpCampaignsTest extends TestCase {
       'from_name' => 'Customer Service',
     ];
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->updateCampaign($campaign_id, $type, $recipients, $settings);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -154,7 +161,8 @@ class MailchimpCampaignsTest extends TestCase {
     ];
     $send_type = 'html';
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->sendTest($campaign_id, $emails, $send_type);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -173,7 +181,8 @@ class MailchimpCampaignsTest extends TestCase {
       'batch_count' => 100,
     ];
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->schedule($campaign_id, $schedule_time, $timewarp, $batch_delivery);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -193,7 +202,8 @@ class MailchimpCampaignsTest extends TestCase {
   public function testUnschedule() {
     $campaign_id = 'b03bfc273a';
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->unschedule($campaign_id);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -206,7 +216,8 @@ class MailchimpCampaignsTest extends TestCase {
   public function testSend() {
     $campaign_id = 'b03bfc273a';
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->send($campaign_id);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -219,7 +230,8 @@ class MailchimpCampaignsTest extends TestCase {
   public function testDelete() {
     $campaign_id = '42694e9e57';
 
-    $mc = new MailchimpCampaigns();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpCampaigns($api_user);
     $mc->delete($campaign_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);

--- a/tests/MailchimpEcommerceTest.php
+++ b/tests/MailchimpEcommerceTest.php
@@ -15,7 +15,8 @@ class MailchimpEcommerceTest extends TestCase {
    * Tests library functionality for stores information.
    */
   public function testGetStores() {
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getStores();
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -28,7 +29,8 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetStore() {
     $store_id = 'MC002';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getStore($store_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -46,7 +48,8 @@ class MailchimpEcommerceTest extends TestCase {
       'currency_code' => 'USD',
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addStore($id, $store);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -70,7 +73,8 @@ class MailchimpEcommerceTest extends TestCase {
     $name = "Freddie's Merchandise";
     $currency_code = 'USD';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updateStore($store_id, $name, $currency_code);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -90,7 +94,8 @@ class MailchimpEcommerceTest extends TestCase {
   public function testDeleteStore() {
     $store_id = 'MC002';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deleteStore($store_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -103,7 +108,8 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetCarts() {
     $store_id = 'MC001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getCarts($store_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -117,7 +123,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $cart_id = 'cart0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getCart($store_id, $cart_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -149,7 +156,8 @@ class MailchimpEcommerceTest extends TestCase {
       ],
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addCart($store_id, $id, $customer, $cart);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -182,7 +190,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $cart_id = 'cart0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updateCart($store_id, $cart_id);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -196,7 +205,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $cart_id = 'cart0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deleteCart($store_id, $cart_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -210,7 +220,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $cart_id = 'cart0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getCartLines($store_id, $cart_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -225,7 +236,8 @@ class MailchimpEcommerceTest extends TestCase {
     $cart_id = 'cart0001';
     $line_id = 'line002';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getCartLine($store_id, $cart_id, $line_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -246,7 +258,8 @@ class MailchimpEcommerceTest extends TestCase {
       'price' => 5,
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addCartLine($store_id, $cart_id, $id, $product);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -271,7 +284,8 @@ class MailchimpEcommerceTest extends TestCase {
     $cart_id = 'cart0001';
     $line_id = 'L001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updateCartLine($store_id, $cart_id, $line_id);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -286,7 +300,8 @@ class MailchimpEcommerceTest extends TestCase {
     $cart_id = 'cart0001';
     $line_id = 'L001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deleteCartLine($store_id, $cart_id, $line_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -299,7 +314,8 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetCustomers() {
     $store_id = 'MC001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getCustomers($store_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -313,7 +329,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $customer_id = 'cust0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getCustomer($store_id, $customer_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -331,7 +348,8 @@ class MailchimpEcommerceTest extends TestCase {
       'opt_in_status' => TRUE,
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addCustomer($store_id, $customer);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -357,7 +375,8 @@ class MailchimpEcommerceTest extends TestCase {
       'opt_in_status' => TRUE,
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updateCustomer($store_id, $customer);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -379,7 +398,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $customer_id = 'cust0003';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deleteCustomer($store_id, $customer_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -392,7 +412,8 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetOrders() {
     $store_id = 'MC001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getOrders($store_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -406,7 +427,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $order_id = 'ord0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getOrder($store_id, $order_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -438,7 +460,8 @@ class MailchimpEcommerceTest extends TestCase {
       ],
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addOrder($store_id, $order_id, $customer, $order);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -471,7 +494,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $order_id = 'ord0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updateOrder($store_id, $order_id);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -485,7 +509,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC002';
     $order_id = 'ord0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deleteOrder($store_id, $order_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -499,7 +524,8 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $order_id = 'ord0001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getOrderLines($store_id, $order_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -514,7 +540,8 @@ class MailchimpEcommerceTest extends TestCase {
     $order_id = 'ord0001';
     $line_id = 'L001';
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getOrderLine($store_id, $order_id, $line_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -535,7 +562,8 @@ class MailchimpEcommerceTest extends TestCase {
       'price' => 5,
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addOrderLine($store_id, $order_id, $id, $product);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -557,7 +585,9 @@ class MailchimpEcommerceTest extends TestCase {
    */
   public function testsGetProducts() {
     $store_id = 'MC001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getProducts($store_id);
     // Method must be GET.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -571,7 +601,9 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetProduct() {
     $store_id = 'MC001';
     $product_id = 'sku0001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getProduct($store_id, $product_id);
     // Method must be GET.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -595,7 +627,8 @@ class MailchimpEcommerceTest extends TestCase {
       $variant_1,
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
 
     $mc->addProduct($store_id, $id, $title, $url, $variants);
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -630,7 +663,8 @@ class MailchimpEcommerceTest extends TestCase {
       $variant_2,
     ];
 
-    $mc = new MailchimpEcommerce();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
 
     $mc->updateProduct($store_id, $id, $variants);
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -652,7 +686,9 @@ class MailchimpEcommerceTest extends TestCase {
   public function testDeleteProduct() {
     $store_id = 'MC001';
     $product_id = 'sku0001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deleteProduct($store_id, $product_id);
     // Method must be DELETE.
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -670,7 +706,9 @@ class MailchimpEcommerceTest extends TestCase {
       'id' => 'var001',
       'title' => 'Var Title',
     ];
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addProductVariant($store_id, $product_id, $params);
     $this->assertEquals('POST', $mc->getClient()->method);
     $this->assertEquals($mc->getEndpoint() . '/ecommerce/stores/' . $store_id . '/products/' . $product_id . '/variants', $mc->getClient()->uri);
@@ -687,7 +725,9 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $product_id = 'sku0001';
     $variant_id = 'var001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deleteProductVariant($store_id, $product_id, $variant_id);
     // Confirm we are using DELETE in the client method.
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -702,7 +742,9 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $product_id = 'sku0001';
     $variant_id = 'var001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getProductVariant($store_id, $product_id, $variant_id);
     // Check method.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -716,7 +758,9 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetVariants() {
     $store_id = 'MC001';
     $product_id = 'sku0001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getProductVariants($store_id, $product_id);
     // Check method.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -737,7 +781,9 @@ class MailchimpEcommerceTest extends TestCase {
       'url' => 'http://www.example.com',
       'sku' => 'abc0042',
     ];
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updateProductVariant($store_id, $product_id, $variant_id, $params);
     // Check method.
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -764,7 +810,9 @@ class MailchimpEcommerceTest extends TestCase {
       'type' => 'fixed',
       'target' => 'total',
     ];
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addPromoRule($store_id, $params);
     // Check method.
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -792,7 +840,9 @@ class MailchimpEcommerceTest extends TestCase {
       'type' => 'percentage',
       'target' => 'per_item',
     ];
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updatePromoRule($store_id, $params);
     // Check method.
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -813,7 +863,9 @@ class MailchimpEcommerceTest extends TestCase {
    */
   public function testGetPromoRules() {
     $store_id = 'MC001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getPromoRules($store_id);
     // Check method.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -827,7 +879,9 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetPromoRule() {
     $store_id = 'MC001';
     $promo_rule_id = 'promo0001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getPromoRule($store_id, $promo_rule_id);
     // Check method.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -841,7 +895,9 @@ class MailchimpEcommerceTest extends TestCase {
   public function testDeletePromoRule() {
     $store_id = 'MC001';
     $promo_rule_id = 'promo0001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deletePromoRule($store_id, $promo_rule_id);
     // Method must be DELETE.
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -861,7 +917,9 @@ class MailchimpEcommerceTest extends TestCase {
       'code' => 'abc0042',
       'redemption_url' => 'http://www.example.com',
     ];
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->addPromoCode($store_id, $promo_rule_id, $params);
     // Check method.
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -885,7 +943,9 @@ class MailchimpEcommerceTest extends TestCase {
       'code' => 'abc0042',
       'redemption_url' => 'http://www.example.com',
     ];
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->updatePromoCode($store_id, $promo_rule_id, $params);
     // Check method.
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -905,7 +965,9 @@ class MailchimpEcommerceTest extends TestCase {
   public function testGetPromoCodes() {
     $store_id = 'MC001';
     $promo_rule_id = 'promo0001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getPromoCodes($store_id, $promo_rule_id);
     // Check method.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -920,7 +982,9 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $promo_rule_id = 'promo0001';
     $promo_code_id = 'code001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->getPromoCode($store_id, $promo_rule_id, $promo_code_id);
     // Check method.
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -935,7 +999,9 @@ class MailchimpEcommerceTest extends TestCase {
     $store_id = 'MC001';
     $promo_rule_id = 'promo0001';
     $promo_code_id = 'code001';
-    $mc = new MailchimpEcommerce();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpEcommerce($api_user);
     $mc->deletePromoCode($store_id, $promo_rule_id, $promo_code_id);
     // Method must be DELETE.
     $this->assertEquals('DELETE', $mc->getClient()->method);

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -15,7 +15,8 @@ class MailchimpListsTest extends TestCase {
    * Tests library functionality for lists information.
    */
   public function testGetLists() {
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getLists();
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -28,7 +29,8 @@ class MailchimpListsTest extends TestCase {
   public function testGetList() {
     $list_id = '57afe96172';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getList($list_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -41,7 +43,8 @@ class MailchimpListsTest extends TestCase {
   public function testGetInterestCategories() {
     $list_id = '57afe96172';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getInterestCategories($list_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -56,7 +59,8 @@ class MailchimpListsTest extends TestCase {
     $title = 'Test Interest Category';
     $type = 'checkbox';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addInterestCategories($list_id, $title, $type);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -79,7 +83,8 @@ class MailchimpListsTest extends TestCase {
     $type = 'dropdown';
     $interest_category_id = '08f0b1d7b2';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->updateInterestCategories($list_id, $interest_category_id, $title, $type);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -100,7 +105,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $interest_category_id = '08f0b1d7b2';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->deleteInterestCategories($list_id, $interest_category_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -114,7 +120,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '';
     $interest_category_id = '';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getInterests($list_id, $interest_category_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -129,7 +136,8 @@ class MailchimpListsTest extends TestCase {
     $interest_category_id = '08f0b1d7b2';
     $name = 'Test Interest';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addInterests($list_id, $interest_category_id, $name);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -151,7 +159,8 @@ class MailchimpListsTest extends TestCase {
     $interest_id = '9143cf3bd1';
     $name = 'Test Interest Edited';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->updateInterests($list_id, $interest_category_id, $interest_id, $name);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -172,7 +181,8 @@ class MailchimpListsTest extends TestCase {
     $interest_category_id = '08f0b1d7b2';
     $interest_id = '9143cf3bd1';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->deleteInterests($list_id, $interest_category_id, $interest_id);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -185,7 +195,8 @@ class MailchimpListsTest extends TestCase {
   public function testGetMergeFields() {
     $list_id = '57afe96172';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getMergeFields($list_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -200,7 +211,8 @@ class MailchimpListsTest extends TestCase {
     $name = 'Phone number';
     $type = 'phone';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addMergeField($list_id, $name, $type);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -218,7 +230,8 @@ class MailchimpListsTest extends TestCase {
   public function testGetMembers() {
     $list_id = '57afe96172';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getMembers($list_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -232,7 +245,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getMemberInfo($list_id, $email);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -246,7 +260,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getMemberActivity($list_id, $email);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -260,7 +275,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getMemberEvents($list_id, $email);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -274,7 +290,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addMember($list_id, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -294,7 +311,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->removeMember($list_id, $email);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -308,7 +326,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->updateMember($list_id, $email);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -322,7 +341,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addOrUpdateMember($list_id, $email);
 
     $this->assertEquals('PUT', $mc->getClient()->method);
@@ -336,7 +356,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getMemberTags($list_id, $email);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -349,7 +370,8 @@ class MailchimpListsTest extends TestCase {
   public function testGetSegments() {
     $list_id = '57afe96172';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getSegments($list_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -363,7 +385,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $segment_id = '49377';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getSegment($list_id, $segment_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -377,7 +400,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '57afe96172';
     $name = 'Test Segment';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addSegment($list_id, $name);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -398,7 +422,8 @@ class MailchimpListsTest extends TestCase {
     $segment_id = '49381';
     $name = 'Updated Test Segment';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->updateSegment($list_id, $segment_id, $name);
 
     $this->assertEquals('PATCH', $mc->getClient()->method);
@@ -418,7 +443,8 @@ class MailchimpListsTest extends TestCase {
     $list_id = '205d96e6b4';
     $segment_id = '457';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->getSegmentMembers($list_id, $segment_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -433,7 +459,8 @@ class MailchimpListsTest extends TestCase {
     $segment_id = '457';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addSegmentMember($list_id, $segment_id, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -454,7 +481,8 @@ class MailchimpListsTest extends TestCase {
     $segment_id = '457';
     $email = 'test@example.com';
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->removeSegmentMember($list_id, $segment_id, $email);
 
     $this->assertEquals('DELETE', $mc->getClient()->method);
@@ -468,7 +496,9 @@ class MailchimpListsTest extends TestCase {
     $list_id = '205d96e6b4';
     $tags = ['Foo', 'Bar'];
     $email = 'test@example.com';
-    $mc = new MailchimpLists();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->addTagsMember($list_id, $tags, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -498,7 +528,9 @@ class MailchimpListsTest extends TestCase {
     $list_id = '205d96e6b4';
     $tags = ['Foo', 'Bar'];
     $email = 'test@example.com';
-    $mc = new MailchimpLists();
+
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->removeTagsMember($list_id, $tags, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);
@@ -534,7 +566,8 @@ class MailchimpListsTest extends TestCase {
         ],
       ];
 
-    $mc = new MailchimpLists();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpLists($api_user);
     $mc->AddMemberEvent($list_id, $email, $event);
 
     $this->assertEquals('POST', $mc->getClient()->method);

--- a/tests/MailchimpReportsTest.php
+++ b/tests/MailchimpReportsTest.php
@@ -15,7 +15,8 @@ class MailchimpReportsTest extends TestCase {
    * Tests library functionality for report information.
    */
   public function testGetSummary() {
-    $mc = new MailchimpReports();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpReports($api_user);
     $mc->getSummary();
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -28,7 +29,8 @@ class MailchimpReportsTest extends TestCase {
   public function testCampaignSummary() {
     $campaign_id = '42694e9e57';
 
-    $mc = new MailchimpReports();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpReports($api_user);
     $mc->getCampaignSummary($campaign_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -42,7 +44,8 @@ class MailchimpReportsTest extends TestCase {
     $campaign_id = '42694e9e57';
     $type = 'email-activity';
 
-    $mc = new MailchimpReports();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpReports($api_user);
     $mc->getCampaignReport($campaign_id, $type);
 
     $this->assertEquals('GET', $mc->getClient()->method);

--- a/tests/MailchimpTemplatesTest.php
+++ b/tests/MailchimpTemplatesTest.php
@@ -15,7 +15,8 @@ class MailchimpTemplatesTest extends TestCase {
    * Tests library functionality for templates information.
    */
   public function testGetTemplates() {
-    $mc = new MailchimpTemplates();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpTemplates($api_user);
     $mc->getTemplates();
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -28,7 +29,8 @@ class MailchimpTemplatesTest extends TestCase {
   public function testGetTemplate() {
     $template_id = '2000094';
 
-    $mc = new MailchimpTemplates();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpTemplates($api_user);
     $mc->getTemplate($template_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -41,7 +43,8 @@ class MailchimpTemplatesTest extends TestCase {
   public function testGetTemplateContent() {
     $template_id = '2000094';
 
-    $mc = new MailchimpTemplates();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpTemplates($api_user);
     $mc->getTemplateContent($template_id);
 
     $this->assertEquals('GET', $mc->getClient()->method);

--- a/tests/MailchimpTest.php
+++ b/tests/MailchimpTest.php
@@ -15,7 +15,8 @@ class MailchimpTest extends TestCase {
    * Tests library functionality for account information.
    */
   public function testGetAccount() {
-    $mc = new Mailchimp();
+    $api_user = new Mailchimp(['api_user' => null, 'api_key' => null]);
+    $mc = new MailchimpApiUser($api_user);
     $mc->getAccount();
 
     $this->assertEquals('GET', $mc->getClient()->method);
@@ -26,7 +27,7 @@ class MailchimpTest extends TestCase {
    * Test the version number.
    */
   public function testVersion() {
-    $mc = new Mailchimp();
+    $mc = new Mailchimp(['api_user' => null, 'api_key' => null]);
     $this->assertEquals($mc::VERSION, '2.0.0');
     $this->assertEquals(json_decode(file_get_contents('composer.json'))->version, $mc::VERSION);
   }

--- a/tests/src/Mailchimp.php
+++ b/tests/src/Mailchimp.php
@@ -12,16 +12,18 @@ class Mailchimp extends \Mailchimp\Mailchimp {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = []) {
+  public function __construct($authentication_settings, $http_options = [], MailchimpHttpClientInterface $client = NULL) {
     $this->client = new MailchimpTestHttpClient();
+
+    parent::__construct($authentication_settings, $http_options, $this->client);
   }
 
   public function getClient() {
-    return $this->client;
+    return $this->api_class->client;
   }
 
   public function getEndpoint() {
-    return $this->endpoint;
+    return 'https://us1.api.mailchimp.com/3.0';
   }
 
 }

--- a/tests/src/MailchimpApiUser.php
+++ b/tests/src/MailchimpApiUser.php
@@ -2,12 +2,7 @@
 
 namespace Mailchimp\Tests;
 
-/**
- * Mailchimp connected sites library test cases.
- *
- * @package Mailchimp\Tests
- */
-class MailchimpConnectedSites extends \Mailchimp\MailchimpConnectedSites {
+class MailchimpApiUser extends \Mailchimp\MailchimpApiUser {
 
   /**
    * @inheritdoc

--- a/tests/src/MailchimpAutomations.php
+++ b/tests/src/MailchimpAutomations.php
@@ -7,16 +7,18 @@ class MailchimpAutomations extends \Mailchimp\MailchimpAutomations {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = []) {
+  public function __construct($api_class = null) {
     $this->client = new MailchimpTestHttpClient();
+
+    parent::__construct($api_class);
   }
 
   public function getClient() {
-    return $this->client;
+    return $this->api_class->client;
   }
 
   public function getEndpoint() {
-    return $this->endpoint;
+    return 'https://us1.api.mailchimp.com/3.0';
   }
 
   /**

--- a/tests/src/MailchimpCampaigns.php
+++ b/tests/src/MailchimpCampaigns.php
@@ -12,16 +12,18 @@ class MailchimpCampaigns extends \Mailchimp\MailchimpCampaigns {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = []) {
+  public function __construct($api_class = null) {
     $this->client = new MailchimpTestHttpClient();
+
+    parent::__construct($api_class);
   }
 
   public function getClient() {
-    return $this->client;
+    return $this->api_class->client;
   }
 
   public function getEndpoint() {
-    return $this->endpoint;
+    return 'https://us1.api.mailchimp.com/3.0';
   }
 
   /**

--- a/tests/src/MailchimpEcommerce.php
+++ b/tests/src/MailchimpEcommerce.php
@@ -35,16 +35,18 @@ class MailchimpEcommerce extends \Mailchimp\MailchimpEcommerce {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = []) {
+  public function __construct($api_class = null) {
     $this->client = new MailchimpTestHttpClient();
-  }
 
+    parent::__construct($api_class);
+  }
+  
   public function getClient() {
-    return $this->client;
+    return $this->api_class->client;
   }
 
   public function getEndpoint() {
-    return $this->endpoint;
+    return 'https://us1.api.mailchimp.com/3.0';
   }
 
   /**

--- a/tests/src/MailchimpLists.php
+++ b/tests/src/MailchimpLists.php
@@ -12,16 +12,18 @@ class MailchimpLists extends \Mailchimp\MailchimpLists {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = []) {
+  public function __construct($api_class = null) {
     $this->client = new MailchimpTestHttpClient();
+
+    parent::__construct($api_class);
   }
 
   public function getClient() {
-    return $this->client;
+    return $this->api_class->client;
   }
 
   public function getEndpoint() {
-    return $this->endpoint;
+    return 'https://us1.api.mailchimp.com/3.0';
   }
 
   /**

--- a/tests/src/MailchimpReports.php
+++ b/tests/src/MailchimpReports.php
@@ -12,16 +12,18 @@ class MailchimpReports extends \Mailchimp\MailchimpReports {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = []) {
+  public function __construct($api_class = null) {
     $this->client = new MailchimpTestHttpClient();
+
+    parent::__construct($api_class);
   }
 
   public function getClient() {
-    return $this->client;
+    return $this->api_class->client;
   }
 
   public function getEndpoint() {
-    return $this->endpoint;
+    return 'https://us1.api.mailchimp.com/3.0';
   }
 
 }

--- a/tests/src/MailchimpTemplates.php
+++ b/tests/src/MailchimpTemplates.php
@@ -12,16 +12,18 @@ class MailchimpTemplates extends \Mailchimp\MailchimpTemplates {
   /**
    * @inheritdoc
    */
-  public function __construct($api_key = 'apikey', $api_user = 'apikey', $http_options = []) {
+  public function __construct($api_class = null) {
     $this->client = new MailchimpTestHttpClient();
+
+    parent::__construct($api_class);
   }
 
   public function getClient() {
-    return $this->client;
+    return $this->api_class->client;
   }
 
   public function getEndpoint() {
-    return $this->endpoint;
+    return 'https://us1.api.mailchimp.com/3.0';
   }
 
 }

--- a/tests/src/MailchimpTestHttpClient.php
+++ b/tests/src/MailchimpTestHttpClient.php
@@ -22,6 +22,7 @@ class MailchimpTestHttpClient implements MailchimpHttpClientInterface {
    * @inheritdoc
    */
   public function handleRequest($method, $uri = '', $options = [], $parameters = [], $returnAssoc = FALSE) {
+
     if (!empty($parameters)) {
       if ($method == 'GET') {
         // Send parameters as query string parameters.


### PR DESCRIPTION
The library was recently restructured and this broke many of the phpunit tests. This PR provides fixes.

Please also see PR #117 