### PR TITLE
Make $batch_operations variable public

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -94,7 +94,7 @@ class Mailchimp implements MailchimpApiInterface {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#create-post_batches
    */
-  private $batch_operations;
+  public $batch_operations;
 
   /**
    * Mailchimp constructor.

--- a/src/Mailchimp2.php
+++ b/src/Mailchimp2.php
@@ -87,7 +87,7 @@ class Mailchimp2 implements MailchimpApiInterface {
    *
    * @see http://developer.mailchimp.com/documentation/mailchimp/reference/batches/#create-post_batches
    */
-  private $batch_operations;
+  public $batch_operations;
 
   /**
    * Authentication settings.


### PR DESCRIPTION
Without it it was not possible to process the batch operations. As an alternative it could use a getter to get the information.

Fixes #119