### PR TITLE
Creation of dynamic properties is deprecated in PHP 8.2.

### DIFF
--- a/tests/src/MailchimpApiUser.php
+++ b/tests/src/MailchimpApiUser.php
@@ -5,6 +5,13 @@ namespace Mailchimp\Tests;
 class MailchimpApiUser extends \Mailchimp\MailchimpApiUser {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * @inheritdoc
    */
   public function __construct($api_class = null) {

--- a/tests/src/MailchimpAutomations.php
+++ b/tests/src/MailchimpAutomations.php
@@ -5,6 +5,13 @@ namespace Mailchimp\Tests;
 class MailchimpAutomations extends \Mailchimp\MailchimpAutomations {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * @inheritdoc
    */
   public function __construct($api_class = null) {

--- a/tests/src/MailchimpCampaigns.php
+++ b/tests/src/MailchimpCampaigns.php
@@ -10,6 +10,13 @@ namespace Mailchimp\Tests;
 class MailchimpCampaigns extends \Mailchimp\MailchimpCampaigns {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * @inheritdoc
    */
   public function __construct($api_class = null) {

--- a/tests/src/MailchimpConnectedSites.php
+++ b/tests/src/MailchimpConnectedSites.php
@@ -10,6 +10,13 @@ namespace Mailchimp\Tests;
 class MailchimpConnectedSites extends \Mailchimp\MailchimpConnectedSites {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * @inheritdoc
    */
   public function __construct($api_class = null) {

--- a/tests/src/MailchimpEcommerce.php
+++ b/tests/src/MailchimpEcommerce.php
@@ -12,6 +12,13 @@ use Mailchimp\MailchimpAPIException;
 class MailchimpEcommerce extends \Mailchimp\MailchimpEcommerce {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * Storage for stores. Used in place of real Mailchimp API.
    *
    * @var array $stores

--- a/tests/src/MailchimpLists.php
+++ b/tests/src/MailchimpLists.php
@@ -10,6 +10,13 @@ namespace Mailchimp\Tests;
 class MailchimpLists extends \Mailchimp\MailchimpLists {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * @inheritdoc
    */
   public function __construct($api_class = null) {

--- a/tests/src/MailchimpReports.php
+++ b/tests/src/MailchimpReports.php
@@ -10,6 +10,13 @@ namespace Mailchimp\Tests;
 class MailchimpReports extends \Mailchimp\MailchimpReports {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * @inheritdoc
    */
   public function __construct($api_class = null) {

--- a/tests/src/MailchimpTemplates.php
+++ b/tests/src/MailchimpTemplates.php
@@ -10,6 +10,13 @@ namespace Mailchimp\Tests;
 class MailchimpTemplates extends \Mailchimp\MailchimpTemplates {
 
   /**
+   * Test HTTP client.
+   *
+   * @var \Mailchimp\http\MailchimpHttpClientInterface
+   */
+  private $client;
+
+  /**
    * @inheritdoc
    */
   public function __construct($api_class = null) {


### PR DESCRIPTION
Fixes #122 